### PR TITLE
[feat] 모임 상세 (MeetingInfo) 화면 네트워크 연결

### DIFF
--- a/KkuMulKum/Network/DTO/Model/Meetings/MeetingMembersResponseModel.swift
+++ b/KkuMulKum/Network/DTO/Model/Meetings/MeetingMembersResponseModel.swift
@@ -15,7 +15,7 @@ struct MeetingMembersModel: ResponseModelType {
 
 struct Member: Codable {
     let memberID: Int
-    let name: String
+    let name: String?
     let profileImageURL: String?
     
     enum CodingKeys: String, CodingKey {

--- a/KkuMulKum/Network/DTO/Model/Promises/MeetingPromisesModel.swift
+++ b/KkuMulKum/Network/DTO/Model/Promises/MeetingPromisesModel.swift
@@ -13,10 +13,19 @@ struct MeetingPromisesModel: ResponseModelType {
 }
 
 struct MeetingPromise: Codable {
-    let id: Int
+    let promiseID: Int
     let name: String
     let dDay: Int
     let date: String
     let time: String
     let placeName: String
+    
+    enum CodingKeys: String, CodingKey {
+        case promiseID = "promiseId"
+        case name
+        case dDay
+        case date
+        case time
+        case placeName
+    }
 }

--- a/KkuMulKum/Network/Service/HomeService.swift
+++ b/KkuMulKum/Network/Service/HomeService.swift
@@ -15,4 +15,27 @@ final class HomeService {
     init(provider: MoyaProvider<HomeTargetType> = MoyaProvider(plugins: [MoyaLoggingPlugin()])) {
         self.provider = provider
     }
+    
+    func request<T: Decodable>(
+        with request: HomeTargetType
+    ) async throws -> ResponseBodyDTO<T>? {
+        return try await withCheckedThrowingContinuation { continuation in
+            provider.request(request) { result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let decodedData = try JSONDecoder().decode(
+                            ResponseBodyDTO<T>.self,
+                            from: response.data
+                        )
+                        continuation.resume(returning: decodedData)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
 }

--- a/KkuMulKum/Network/Service/MeetingService.swift
+++ b/KkuMulKum/Network/Service/MeetingService.swift
@@ -15,4 +15,27 @@ final class MeetingService {
     init(provider: MoyaProvider<MeetingTargetType> = MoyaProvider(plugins: [MoyaLoggingPlugin()])) {
         self.provider = provider
     }
+    
+    func request<T: Decodable>(
+        with request: MeetingTargetType
+    ) async throws -> ResponseBodyDTO<T>? {
+        return try await withCheckedThrowingContinuation { continuation in
+            provider.request(request) { result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let decodedData = try JSONDecoder().decode(
+                            ResponseBodyDTO<T>.self,
+                            from: response.data
+                        )
+                        continuation.resume(returning: decodedData)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
 }

--- a/KkuMulKum/Network/Service/PromiseService.swift
+++ b/KkuMulKum/Network/Service/PromiseService.swift
@@ -12,8 +12,31 @@ import Moya
 final class PromiseService {
     let provider: MoyaProvider<PromiseTargetType>
     
-    init(provider: MoyaProvider<PromiseTargetType> = MoyaProvider(plugins: [MoyaLoggingPlugin()])
-    ) {
+    init(provider: MoyaProvider<PromiseTargetType> = MoyaProvider(plugins: [MoyaLoggingPlugin()])) {
         self.provider = provider
     }
+    
+    func request<T: Decodable>(
+        with request: PromiseTargetType
+    ) async throws -> ResponseBodyDTO<T>? {
+        return try await withCheckedThrowingContinuation { continuation in
+            provider.request(request) { result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let decodedData = try JSONDecoder().decode(
+                            ResponseBodyDTO<T>.self,
+                            from: response.data
+                        )
+                        continuation.resume(returning: decodedData)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
 }

--- a/KkuMulKum/Network/TargetType/MeetingTargetType.swift
+++ b/KkuMulKum/Network/TargetType/MeetingTargetType.swift
@@ -15,6 +15,7 @@ enum MeetingTargetType {
     case fetchMeetingList
     case fetchMeetingInfo(meetingID: Int)
     case fetchMeetingMember(meetingID: Int)
+    case fetchmeetingPromiseList(meetingID: Int)
 }
 
 extension MeetingTargetType: TargetType {
@@ -39,6 +40,8 @@ extension MeetingTargetType: TargetType {
             return "/api/v1/meetings/\(meetingID)"
         case .fetchMeetingMember(meetingID: let meetingID):
             return "/api/v1/meetings/\(meetingID)/members"
+        case .fetchmeetingPromiseList(let meetingID):
+            return "/api/v1/meetings/\(meetingID)/promises"
         }
     }
     
@@ -46,7 +49,7 @@ extension MeetingTargetType: TargetType {
         switch self {
         case .createMeeting, .joinMeeting:
             return .post
-        case .fetchMeetingList, .fetchMeetingInfo, .fetchMeetingMember:
+        case .fetchMeetingList, .fetchMeetingInfo, .fetchMeetingMember, .fetchmeetingPromiseList:
             return .get
         }
     }
@@ -57,7 +60,7 @@ extension MeetingTargetType: TargetType {
             return .requestJSONEncodable(request)
         case .joinMeeting(request: let request):
             return .requestJSONEncodable(request)
-        case .fetchMeetingList, .fetchMeetingInfo, .fetchMeetingMember:
+        case .fetchMeetingList, .fetchMeetingInfo, .fetchMeetingMember, .fetchmeetingPromiseList:
             return .requestPlain
         }
     }

--- a/KkuMulKum/Network/TargetType/MeetingTargetType.swift
+++ b/KkuMulKum/Network/TargetType/MeetingTargetType.swift
@@ -15,7 +15,7 @@ enum MeetingTargetType {
     case fetchMeetingList
     case fetchMeetingInfo(meetingID: Int)
     case fetchMeetingMember(meetingID: Int)
-    case fetchmeetingPromiseList(meetingID: Int)
+    case fetchMeetingPromiseList(meetingID: Int)
 }
 
 extension MeetingTargetType: TargetType {
@@ -40,7 +40,7 @@ extension MeetingTargetType: TargetType {
             return "/api/v1/meetings/\(meetingID)"
         case .fetchMeetingMember(meetingID: let meetingID):
             return "/api/v1/meetings/\(meetingID)/members"
-        case .fetchmeetingPromiseList(let meetingID):
+        case .fetchMeetingPromiseList(let meetingID):
             return "/api/v1/meetings/\(meetingID)/promises"
         }
     }
@@ -49,7 +49,7 @@ extension MeetingTargetType: TargetType {
         switch self {
         case .createMeeting, .joinMeeting:
             return .post
-        case .fetchMeetingList, .fetchMeetingInfo, .fetchMeetingMember, .fetchmeetingPromiseList:
+        case .fetchMeetingList, .fetchMeetingInfo, .fetchMeetingMember, .fetchMeetingPromiseList:
             return .get
         }
     }
@@ -60,7 +60,7 @@ extension MeetingTargetType: TargetType {
             return .requestJSONEncodable(request)
         case .joinMeeting(request: let request):
             return .requestJSONEncodable(request)
-        case .fetchMeetingList, .fetchMeetingInfo, .fetchMeetingMember, .fetchmeetingPromiseList:
+        case .fetchMeetingList, .fetchMeetingInfo, .fetchMeetingMember, .fetchMeetingPromiseList:
             return .requestPlain
         }
     }

--- a/KkuMulKum/Network/TargetType/PromiseTargetType.swift
+++ b/KkuMulKum/Network/TargetType/PromiseTargetType.swift
@@ -15,7 +15,7 @@ enum PromiseTargetType {
     case updatePreparationStatus(promiseID: Int)
     case updateDepartureStatus(promiseID: Int)
     case updateArrivalStatus(promiseID: Int)
-    case fetchmeetingPromiseList(meetingID: Int, request: PromiseInfoModel)
+    case fetchmeetingPromiseList(meetingID: Int)
     case addPromise(meetingID: Int, request: AddPromiseRequestModel)
     case fetchPromiseInfo(promiseID: Int)
     case fetchMyReadyStatus(promiseID: Int)
@@ -47,10 +47,10 @@ extension PromiseTargetType: TargetType {
             return "/api/v1/promises/\(promiseID)/departure"
         case .updateArrivalStatus(let promiseID):
             return "/api/v1/promises/\(promiseID)/arrival"
-        case .fetchmeetingPromiseList(let meetingID, _):
-            return "/api/v1/promises/\(meetingID)/promises"
+        case .fetchmeetingPromiseList(let meetingID):
+            return "/api/v1/meetings/\(meetingID)/promises"
         case .addPromise(let meetingID, _):
-            return "/api/v1/promises/\(meetingID)/promises"
+            return "/api/v1/meetings/\(meetingID)/promises"
         case .fetchPromiseInfo(let promiseID):
             return "/api/v1/promises/\(promiseID)"
         case .fetchMyReadyStatus(let promiseID):
@@ -85,10 +85,8 @@ extension PromiseTargetType: TargetType {
         case .fetchTodayNextPromise, .fetchUpcomingPromiseList, .updatePreparationStatus,
                 .updateDepartureStatus, .updateArrivalStatus, .fetchPromiseInfo,
                 .fetchMyReadyStatus, .fetchPromiseParticipantList, .updateMyPromiseReadyStatus,
-                .fetchTardyInfo, .updatePromiseCompletion:
+                .fetchTardyInfo, .updatePromiseCompletion, .fetchmeetingPromiseList:
             return .requestPlain
-        case .fetchmeetingPromiseList(_, let request):
-            return .requestJSONEncodable(request)
         case .addPromise(_, let request):
             return .requestJSONEncodable(request)
         }

--- a/KkuMulKum/Network/TargetType/PromiseTargetType.swift
+++ b/KkuMulKum/Network/TargetType/PromiseTargetType.swift
@@ -15,7 +15,7 @@ enum PromiseTargetType {
     case updatePreparationStatus(promiseID: Int)
     case updateDepartureStatus(promiseID: Int)
     case updateArrivalStatus(promiseID: Int)
-    case fetchmeetingPromiseList(meetingID: Int)
+    case fetchMeetingPromiseList(meetingID: Int)
     case addPromise(meetingID: Int, request: AddPromiseRequestModel)
     case fetchPromiseInfo(promiseID: Int)
     case fetchMyReadyStatus(promiseID: Int)
@@ -47,7 +47,7 @@ extension PromiseTargetType: TargetType {
             return "/api/v1/promises/\(promiseID)/departure"
         case .updateArrivalStatus(let promiseID):
             return "/api/v1/promises/\(promiseID)/arrival"
-        case .fetchmeetingPromiseList(let meetingID):
+        case .fetchMeetingPromiseList(let meetingID):
             return "/api/v1/meetings/\(meetingID)/promises"
         case .addPromise(let meetingID, _):
             return "/api/v1/meetings/\(meetingID)/promises"
@@ -68,7 +68,7 @@ extension PromiseTargetType: TargetType {
     
     var method: Moya.Method {
         switch self {
-        case .fetchTodayNextPromise, .fetchUpcomingPromiseList, .fetchmeetingPromiseList, 
+        case .fetchTodayNextPromise, .fetchUpcomingPromiseList, .fetchMeetingPromiseList, 
                 .fetchPromiseInfo, .fetchMyReadyStatus, .fetchPromiseParticipantList,
                 .fetchTardyInfo:
             return .get
@@ -85,7 +85,7 @@ extension PromiseTargetType: TargetType {
         case .fetchTodayNextPromise, .fetchUpcomingPromiseList, .updatePreparationStatus,
                 .updateDepartureStatus, .updateArrivalStatus, .fetchPromiseInfo,
                 .fetchMyReadyStatus, .fetchPromiseParticipantList, .updateMyPromiseReadyStatus,
-                .fetchTardyInfo, .updatePromiseCompletion, .fetchmeetingPromiseList:
+                .fetchTardyInfo, .updatePromiseCompletion, .fetchMeetingPromiseList:
             return .requestPlain
         case .addPromise(_, let request):
             return .requestJSONEncodable(request)

--- a/KkuMulKum/Source/AddPromise/Cell/SelectMemberCell.swift
+++ b/KkuMulKum/Source/AddPromise/Cell/SelectMemberCell.swift
@@ -63,7 +63,7 @@ extension SelectMemberCell {
     func configure(with member: Member) {
         self.member = member
         
-        nameLabel.setText(member.name, style: .body06, color: .gray6)
+        nameLabel.setText(member.name ?? " ", style: .body06, color: .gray6)
         profileImageView.image = .imgProfile.withRenderingMode(.alwaysOriginal)
         guard let imageURL = URL(string: member.profileImageURL ?? "") else { return }
         profileImageView.kf.setImage(with: imageURL)

--- a/KkuMulKum/Source/MeetingInfo/Cell/MeetingMemberCell.swift
+++ b/KkuMulKum/Source/MeetingInfo/Cell/MeetingMemberCell.swift
@@ -102,7 +102,7 @@ private extension MeetingMemberCell {
         let name = member.name
         let imageURL = member.profileImageURL
         
-        nameLabel.setText(name, style: .caption02, color: .gray6)
+        nameLabel.setText(name ?? " ", style: .caption02, color: .gray6)
         profileImageButton.setImage(
             .imgProfile.withRenderingMode(.alwaysOriginal),
             for: .normal

--- a/KkuMulKum/Source/MeetingInfo/Service/MeetingInfoService.swift
+++ b/KkuMulKum/Source/MeetingInfo/Service/MeetingInfoService.swift
@@ -31,7 +31,7 @@ extension MeetingService: MeetingInfoServiceType {
     func fetchMeetingPromiseList(
         with meetingID: Int
     ) async throws -> ResponseBodyDTO<MeetingPromisesModel>? {
-        return try await request(with: .fetchmeetingPromiseList(meetingID: meetingID))
+        return try await request(with: .fetchMeetingPromiseList(meetingID: meetingID))
     }    
 }
 

--- a/KkuMulKum/Source/MeetingInfo/Service/MeetingInfoService.swift
+++ b/KkuMulKum/Source/MeetingInfo/Service/MeetingInfoService.swift
@@ -8,13 +8,86 @@
 import Foundation
 
 protocol MeetingInfoServiceType {
-    func fetchMeetingInfo(with meetingID: Int) -> MeetingInfoModel?
-    func fetchMeetingMemberList(with meetingID: Int) -> MeetingMembersModel?
-    func fetchMeetingPromiseList(with meetingID: Int) -> MeetingPromisesModel?
+    func fetchMeetingInfo(with meetingID: Int) async throws -> ResponseBodyDTO<MeetingInfoModel>?
+    func fetchMeetingMemberList(
+        with meetingID: Int
+    ) async throws -> ResponseBodyDTO<MeetingMembersModel>?
+    func fetchMeetingPromiseList(
+        with meetingID: Int
+    ) async throws -> ResponseBodyDTO<MeetingPromisesModel>?
+}
+
+extension MeetingService: MeetingInfoServiceType {
+    func fetchMeetingInfo(with meetingID: Int) async throws -> ResponseBodyDTO<MeetingInfoModel>? {
+        try await withCheckedThrowingContinuation { continuation in
+            provider.request(.fetchMeetingInfo(meetingID: meetingID)) { result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let decodedData = try JSONDecoder().decode(
+                            ResponseBodyDTO<MeetingInfoModel>.self,
+                            from: response.data
+                        )
+                        continuation.resume(returning: decodedData)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+    
+    func fetchMeetingMemberList(
+        with meetingID: Int
+    ) async throws -> ResponseBodyDTO<MeetingMembersModel>? {
+        try await withCheckedThrowingContinuation { continuation in
+            provider.request(.fetchMeetingMember(meetingID: meetingID)) { result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let decodedData = try JSONDecoder().decode(
+                            ResponseBodyDTO<MeetingMembersModel>.self,
+                            from: response.data
+                        )
+                        continuation.resume(returning: decodedData)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+    
+    func fetchMeetingPromiseList(
+        with meetingID: Int
+    ) async throws -> ResponseBodyDTO<MeetingPromisesModel>? {
+        try await withCheckedThrowingContinuation { continuation in
+            provider.request(.fetchmeetingPromiseList(meetingID: meetingID)) { result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let decodedData = try JSONDecoder().decode(
+                            ResponseBodyDTO<MeetingPromisesModel>.self,
+                            from: response.data
+                        )
+                        continuation.resume(returning: decodedData)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
 }
 
 final class MockMeetingInfoService: MeetingInfoServiceType {
-    func fetchMeetingInfo(with meetingID: Int) -> MeetingInfoModel? {
+    func fetchMeetingInfo(with meetingID: Int) -> ResponseBodyDTO<MeetingInfoModel>? {
         let mockData = MeetingInfoModel(
             meetingID: 1,
             name: "웅웅난진웅",
@@ -23,10 +96,10 @@ final class MockMeetingInfoService: MeetingInfoServiceType {
             invitationCode: "WD56CQ"
         )
         
-        return mockData
+        return ResponseBodyDTO(success: true, data: mockData, error: nil)
     }
     
-    func fetchMeetingMemberList(with meetingID: Int) -> MeetingMembersModel? {
+    func fetchMeetingMemberList(with meetingID: Int) -> ResponseBodyDTO<MeetingMembersModel>? {
         let mockData = MeetingMembersModel(
             memberCount: 14,
             members: [
@@ -103,14 +176,14 @@ final class MockMeetingInfoService: MeetingInfoServiceType {
             ]
         )
         
-        return mockData
+        return ResponseBodyDTO(success: true, data: mockData, error: nil)
     }
     
-    func fetchMeetingPromiseList(with meetingID: Int) -> MeetingPromisesModel? {
+    func fetchMeetingPromiseList(with meetingID: Int) -> ResponseBodyDTO<MeetingPromisesModel>? {
         let mockData = MeetingPromisesModel(
             promises: [
                 MeetingPromise(
-                    id: 1,
+                    promiseID: 1,
                     name: "꾸물 리프레시 데이",
                     dDay: 0,
                     date: "2024.07.20",
@@ -118,7 +191,7 @@ final class MockMeetingInfoService: MeetingInfoServiceType {
                     placeName: "DMC역"
                 ),
                 MeetingPromise(
-                    id: 2,
+                    promiseID: 2,
                     name: "꾸물 잼얘 나이트", 
                     dDay: 10,
                     date: "2024.07.30",
@@ -126,7 +199,7 @@ final class MockMeetingInfoService: MeetingInfoServiceType {
                     placeName: "홍대입구"
                 ),
                 MeetingPromise(
-                    id: 3,
+                    promiseID: 3,
                     name: "친구 생일 파티",
                     dDay: 5,
                     date: "2024.07.25",
@@ -134,7 +207,7 @@ final class MockMeetingInfoService: MeetingInfoServiceType {
                     placeName: "강남역"
                 ),
                 MeetingPromise(
-                    id: 4,
+                    promiseID: 4,
                     name: "주말 산책",
                     dDay: 3,
                     date: "2024.07.23",
@@ -142,7 +215,7 @@ final class MockMeetingInfoService: MeetingInfoServiceType {
                     placeName: "서울숲"
                 ),
                 MeetingPromise(
-                    id: 5,
+                    promiseID: 5,
                     name: "프로젝트 미팅",
                     dDay: 1,
                     date: "2024.07.21",
@@ -150,7 +223,7 @@ final class MockMeetingInfoService: MeetingInfoServiceType {
                     placeName: "삼성역"
                 ),
                 MeetingPromise(
-                    id: 6,
+                    promiseID: 6,
                     name: "독서 모임",
                     dDay: 7, 
                     date: "2024.07.27",
@@ -158,7 +231,7 @@ final class MockMeetingInfoService: MeetingInfoServiceType {
                     placeName: "합정역"
                 ),
                 MeetingPromise(
-                    id: 7,
+                    promiseID: 7,
                     name: "헬스클럽 모임",
                     dDay: 2,
                     date: "2024.07.22",
@@ -166,7 +239,7 @@ final class MockMeetingInfoService: MeetingInfoServiceType {
                     placeName: "신촌역"
                 ),
                 MeetingPromise(
-                    id: 8,
+                    promiseID: 8,
                     name: "영화 관람",
                     dDay: 4,
                     date: "2024.07.24",
@@ -174,7 +247,7 @@ final class MockMeetingInfoService: MeetingInfoServiceType {
                     placeName: "잠실역"
                 ),
                 MeetingPromise(
-                    id: 9,
+                    promiseID: 9,
                     name: "저녁 식사",
                     dDay: 6,
                     date: "2024.07.26",
@@ -182,7 +255,7 @@ final class MockMeetingInfoService: MeetingInfoServiceType {
                     placeName: "이태원역"
                 ),
                 MeetingPromise(
-                    id: 10,
+                    promiseID: 10,
                     name: "아침 조깅",
                     dDay: 14,
                     date: "2024.08.03",
@@ -190,7 +263,7 @@ final class MockMeetingInfoService: MeetingInfoServiceType {
                     placeName: "한강공원"
                 ),
                 MeetingPromise(
-                    id: 11,
+                    promiseID: 11,
                     name: "커피 브레이크",
                     dDay: 8,
                     date: "2024.07.28",
@@ -198,7 +271,7 @@ final class MockMeetingInfoService: MeetingInfoServiceType {
                     placeName: "을지로입구"
                 ),
                 MeetingPromise(
-                    id: 12,
+                    promiseID: 12,
                     name: "스터디 그룹",
                     dDay: 12,
                     date: "2024.08.01",
@@ -206,7 +279,7 @@ final class MockMeetingInfoService: MeetingInfoServiceType {
                     placeName: "강남역"
                 ),
                 MeetingPromise(
-                    id: 13,
+                    promiseID: 13,
                     name: "뮤직 페스티벌",
                     dDay: 9,
                     date: "2024.07.29",
@@ -214,7 +287,7 @@ final class MockMeetingInfoService: MeetingInfoServiceType {
                     placeName: "난지공원"
                 ),
                 MeetingPromise(
-                    id: 14,
+                    promiseID: 14,
                     name: "낚시 여행",
                     dDay: 11,
                     date: "2024.07.31",
@@ -222,7 +295,7 @@ final class MockMeetingInfoService: MeetingInfoServiceType {
                     placeName: "속초항"
                 ),
                 MeetingPromise(
-                    id: 15,
+                    promiseID: 15,
                     name: "가족 모임",
                     dDay: 13,
                     date: "2024.08.02",
@@ -232,6 +305,6 @@ final class MockMeetingInfoService: MeetingInfoServiceType {
             ]
         )
         
-        return mockData
+        return ResponseBodyDTO(success: true, data: mockData, error: nil)
     }
 }

--- a/KkuMulKum/Source/MeetingInfo/Service/MeetingInfoService.swift
+++ b/KkuMulKum/Source/MeetingInfo/Service/MeetingInfoService.swift
@@ -19,71 +19,20 @@ protocol MeetingInfoServiceType {
 
 extension MeetingService: MeetingInfoServiceType {
     func fetchMeetingInfo(with meetingID: Int) async throws -> ResponseBodyDTO<MeetingInfoModel>? {
-        try await withCheckedThrowingContinuation { continuation in
-            provider.request(.fetchMeetingInfo(meetingID: meetingID)) { result in
-                switch result {
-                case .success(let response):
-                    do {
-                        let decodedData = try JSONDecoder().decode(
-                            ResponseBodyDTO<MeetingInfoModel>.self,
-                            from: response.data
-                        )
-                        continuation.resume(returning: decodedData)
-                    } catch {
-                        continuation.resume(throwing: error)
-                    }
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
+        return try await request(with: .fetchMeetingInfo(meetingID: meetingID))
     }
     
     func fetchMeetingMemberList(
         with meetingID: Int
     ) async throws -> ResponseBodyDTO<MeetingMembersModel>? {
-        try await withCheckedThrowingContinuation { continuation in
-            provider.request(.fetchMeetingMember(meetingID: meetingID)) { result in
-                switch result {
-                case .success(let response):
-                    do {
-                        let decodedData = try JSONDecoder().decode(
-                            ResponseBodyDTO<MeetingMembersModel>.self,
-                            from: response.data
-                        )
-                        continuation.resume(returning: decodedData)
-                    } catch {
-                        continuation.resume(throwing: error)
-                    }
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
+        return try await request(with: .fetchMeetingMember(meetingID: meetingID))
     }
     
     func fetchMeetingPromiseList(
         with meetingID: Int
     ) async throws -> ResponseBodyDTO<MeetingPromisesModel>? {
-        try await withCheckedThrowingContinuation { continuation in
-            provider.request(.fetchmeetingPromiseList(meetingID: meetingID)) { result in
-                switch result {
-                case .success(let response):
-                    do {
-                        let decodedData = try JSONDecoder().decode(
-                            ResponseBodyDTO<MeetingPromisesModel>.self,
-                            from: response.data
-                        )
-                        continuation.resume(returning: decodedData)
-                    } catch {
-                        continuation.resume(throwing: error)
-                    }
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
-    }
+        return try await request(with: .fetchmeetingPromiseList(meetingID: meetingID))
+    }    
 }
 
 final class MockMeetingInfoService: MeetingInfoServiceType {

--- a/KkuMulKum/Source/MeetingInfo/ViewController/MeetingInfoViewController.swift
+++ b/KkuMulKum/Source/MeetingInfo/ViewController/MeetingInfoViewController.swift
@@ -79,7 +79,6 @@ private extension MeetingInfoViewController {
         output.info
             .drive(with: self) { owner, meetingInfo in
                 guard let info = meetingInfo else { return }
-                
                 owner.title = info.name
                 owner.rootView.configureInfo(
                     createdAt: info.createdAt,
@@ -109,6 +108,10 @@ private extension MeetingInfoViewController {
             .disposed(by: disposeBag)
         
         output.promises
+            .map { [weak self] promises in
+                self?.rootView.configureEmptyView(with: !promises.isEmpty)
+                return promises
+            }
             .drive(rootView.promiseListView.rx.items(
                 cellIdentifier: MeetingPromiseCell.reuseIdentifier,
                 cellType: MeetingPromiseCell.self
@@ -135,18 +138,14 @@ private extension MeetingInfoViewController {
                     )
                     return
                 }
-                
                 owner.navigateToAddPromise()
             }
             .disposed(by: disposeBag)
-        
-        rootView.configureEmptyView(with: viewModel.meetingPromises.count == 0)
     }
     
     func navigateToAddPromise() {
         let viewModel = AddPromiseViewModel(meetingID: viewModel.meetingID)
         let viewController = AddPromiseViewController(viewModel: viewModel)
-        
         navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/KkuMulKum/Source/MeetingList/ViewController/MeetingListViewController.swift
+++ b/KkuMulKum/Source/MeetingList/ViewController/MeetingListViewController.swift
@@ -85,13 +85,13 @@ extension MeetingListViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        // TODO: MeetingID를 넘겨받기
         let viewController = MeetingInfoViewController(
             viewModel: MeetingInfoViewModel(
-                meetingID: 1,
-                service: MockMeetingInfoService()
+                meetingID: 8,
+                service: MeetingService()
             )
         )
-        
         tabBarController?.navigationController?.pushViewController(viewController, animated: true)
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #215 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 모임 상세 화면 네트워크 연결
- 단, 눌린 셀로부터 MeetingID를 넘겨받고 있지 않음 (@mmaybei 부탁드려용~)

|    구현 내용    |   IPhone 15 pro   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/af20a021-a35a-4c12-882f-2070e96e5c13" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 당신을 클로저 콜백 지옥에서 구출해줄 코드
#### async/await
- Swift Concurrency로 도입된 async/await 구문은 보다 간편하면서도 간결한 비동기 작업 코드를 작성할 수 있게 합니다.
- 일반적인 함수 호출과 같은 코드 형태를 띄기 때문에 보다 사용하기 간편하다는 장점이 있습니다.

<details>
<summary>Async/Await 구문 예시</summary>

```swift
/// 일반적인 클로저 형태 (호출하는 입장에서..)
fetchData { data, error in
    processData(data) { processedData, error in
        saveData(processedData) { success, error in
            // 처리 완료
        }
    }
}

/// Async/Await 구문

func fetchData() async -> Data? {
    // 비동기 네트워크 호출
}

func processData() async -> ProcessedData? {
    if let data = await fetchData() {
        // 데이터를 처리
        return processedData
    }
    return nil
}

async {
    if let processedData = await processData() {
        // 처리된 데이터 사용
    }
}
```
</details>

#### withCheckedThrowingContinuation
- 클로저(콜백) 기반의 비동기 작업을 async/await 스타일로 변환할 때 사용합니다.
- withCheckedThrowingContinuation는 예외를 던질 수 있는 비동기 작업을 처리하기 위해 사용됩니다.
- 클로저를 받아서 비동기 작업을 수행하며, 클로저 내부에서 continuation 객체를 사용하여 작업의 결과를 반환하거나 예외를 던집니다.
- Swift 5.5에서 등장했습니다.

<details>
<summary>Async/Await 구문 예시</summary>

```swift
/// 일반적인 클로저 형태 (호출하는 입장에서..)
func fetchData(completion: @escaping (Result<Data, Error>) -> Void) {
    // 네트워크 요청 코드
    let url = URL(string: "https://api.example.com/data")!
    let task = URLSession.shared.dataTask(with: url) { data, response, error in
        if let error = error {
            completion(.failure(error))
        } else if let data = data {
            completion(.success(data))
        }
    }
    task.resume()
}

/// withCheckedThrowingContinuation

func fetchData() async throws -> Data {
    return try await withCheckedThrowingContinuation { continuation in
        fetchData { result in
            switch result {
            case .success(let data):
                continuation.resume(returning: data)
            case .failure(let error):
                continuation.resume(throwing: error)
            }
        }
    }
}
```
</details>

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- [Async/Await에 대해서 반드시 봐야할 영상](https://developer.apple.com/videos/play/wwdc2021/10132/)
    - 구글 확장 프로그램 'WWDC 한글 자막'을 반드시 추가하고 보세요
## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 하지만 사실 여러분들 더 사용하기 편하시라고 코드를 분리해 두었습니다. request 메서드만 호출해도 무방해요!
<details>
<summary>요로코롬</summary>

```swift
extension MeetingService: MeetingInfoServiceType {
    func fetchMeetingInfo(with meetingID: Int) async throws -> ResponseBodyDTO<MeetingInfoModel>? {
        return try await request(with: .fetchMeetingInfo(meetingID: meetingID))
    }
    
    func fetchMeetingMemberList(
        with meetingID: Int
    ) async throws -> ResponseBodyDTO<MeetingMembersModel>? {
        return try await request(with: .fetchMeetingMember(meetingID: meetingID))
    }
    
    func fetchMeetingPromiseList(
        with meetingID: Int
    ) async throws -> ResponseBodyDTO<MeetingPromisesModel>? {
        return try await request(with: .fetchmeetingPromiseList(meetingID: meetingID))
    }    
}
```
</details>