### PR TITLE
[refactor] 모임 상세에서 약속 상세로 이동하기 위한 코드 리팩토링

### DIFF
--- a/KkuMulKum/Source/MeetingInfo/Cell/MeetingPromiseCell.swift
+++ b/KkuMulKum/Source/MeetingInfo/Cell/MeetingPromiseCell.swift
@@ -93,7 +93,7 @@ final class MeetingPromiseCell: BaseCollectionViewCell {
 
 extension MeetingPromiseCell {
     func configure(dDay: Int, name: String, date: String, time: String, place: String) {
-        let dDayText = dDay == 0 ? "day" : "\(dDay)"
+        let dDayText = dDay == 0 ? "Day" : "\(dDay)"
         dDayLabel.setText("D-\(dDayText)", style: .body05, color: dDay == 0 ? .mainorange : .gray5)
         nameLabel.setText(name, style: .body03, color: .gray8)
         dateLabel.setText(date, style: .body06, color: .gray7)

--- a/KkuMulKum/Source/MeetingInfo/ViewController/MeetingInfoViewController.swift
+++ b/KkuMulKum/Source/MeetingInfo/ViewController/MeetingInfoViewController.swift
@@ -65,6 +65,18 @@ final class MeetingInfoViewController: BaseViewController {
     override func setupView() {
         setupNavigationBarBackButton()
     }
+    
+    override func setupDelegate() {
+        rootView.promiseListView.delegate = self
+    }
+}
+
+extension MeetingInfoViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        // TODO: promiseID를 모임 상세로 전달
+        /// viewModel.meetingPromises[indexPath.item]을 전달
+        print(">>> \(viewModel.meetingPromises[indexPath.item]) : \(#function)")
+    }
 }
 
 private extension MeetingInfoViewController {


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #221 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- Cell Delegate 메서드 `didSelectItemAt` 을 이용하여 셀 선택시, 뷰모델 배열에 접근하여 선택된 모임을 추출
- print문은 추후 삭제 요망 (@youz2me )

|    구현 내용    |  사진  |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/301d10af-7298-48ba-ace3-8370ed93cb9e"> |
