### PR TITLE
[feat] 홈 화면 및 내 모임 리스트 화면 연결

### DIFF
--- a/KkuMulKum/Source/Home/View/HomeView.swift
+++ b/KkuMulKum/Source/Home/View/HomeView.swift
@@ -64,7 +64,7 @@ final class HomeView: BaseView {
         $0.setText("다가올 나의 약속은?", style: .body01, color: .gray8)
     }
     
-    private let todayButton = UIButton().then {
+    let todayButton = UIButton().then {
         let icon = UIImage(resource: .iconRight)
         $0.setImage(icon, for: .normal)
     }

--- a/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
+++ b/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
@@ -116,6 +116,20 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
     ) -> UIEdgeInsets {
         return contentInset
     }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        didSelectItemAt indexPath: IndexPath
+    ) {
+        // TODO: promiseID를 모임 상세로 전달
+//        let viewController = PromiseInfoViewController(
+//            viewModel: PromiseInfoViewModel(
+//                promiseID: viewModel.upcomingPromiseList.value?.data?.promises[indexPath.item].promiseID ?? 0,
+//                service: PromiseService()
+//            )
+//        )
+        //tabBarController?.navigationController?.pushViewController(viewController, animated: true)
+    }
 }
 
 

--- a/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
+++ b/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
@@ -65,6 +65,11 @@ class HomeViewController: BaseViewController {
     }
     
     override func setupAction() {
+        rootView.todayButton.addTarget(
+            self,
+            action: #selector(todayButtonDidTap),
+            for: .touchUpInside
+        )
         rootView.todayPromiseView.prepareButton.addTarget(
             self,
             action: #selector(prepareButtonDidTap),
@@ -367,6 +372,18 @@ private extension HomeViewController {
     
     
     // MARK: - Action
+    
+    @objc
+    func todayButtonDidTap(_ sender: UIButton) {
+        // TODO: promiseID를 모임 상세로 전달
+//        let viewController = PromiseInfoViewController(
+//            viewModel: PromiseInfoViewModel(
+//                promiseID: viewModel.nearestPromise.value?.data?.promiseID ?? 0,
+//                service: PromiseService()
+//            )
+//        )
+        //tabBarController?.navigationController?.pushViewController(viewController, animated: true)
+    }
     
     @objc
     func prepareButtonDidTap(_ sender: UIButton) {

--- a/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
+++ b/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
@@ -127,6 +127,10 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
         didSelectItemAt indexPath: IndexPath
     ) {
         // TODO: promiseID를 모임 상세로 전달
+        print(
+            "promiseID: ",
+            viewModel.upcomingPromiseList.value?.data?.promises[indexPath.item].promiseID ?? 0
+        )
 //        let viewController = PromiseInfoViewController(
 //            viewModel: PromiseInfoViewModel(
 //                promiseID: viewModel.upcomingPromiseList.value?.data?.promises[indexPath.item].promiseID ?? 0,
@@ -375,6 +379,10 @@ private extension HomeViewController {
     
     @objc
     func todayButtonDidTap(_ sender: UIButton) {
+        print(
+            "promiseID: ",
+            viewModel.nearestPromise.value?.data?.promiseID ?? 0
+        )
         // TODO: promiseID를 모임 상세로 전달
 //        let viewController = PromiseInfoViewController(
 //            viewModel: PromiseInfoViewModel(

--- a/KkuMulKum/Source/MeetingList/ServiceType/MeetingListServiceType.swift
+++ b/KkuMulKum/Source/MeetingList/ServiceType/MeetingListServiceType.swift
@@ -13,6 +13,12 @@ protocol MeetingListServiceType {
     func fetchMeetingList() -> ResponseBodyDTO<MeetingListModel>
 }
 
+//extension MeetingService: MeetingListServiceType {
+//    func fetchMeetingList() -> ResponseBodyDTO<MeetingListModel> {
+//        <#code#>
+//    }
+//}
+
 final class MockMeetingListService: MeetingListServiceType {
     func fetchMeetingList() -> ResponseBodyDTO<MeetingListModel> {
         let mockData = ResponseBodyDTO<MeetingListModel>(

--- a/KkuMulKum/Source/MeetingList/ViewController/MeetingListViewController.swift
+++ b/KkuMulKum/Source/MeetingList/ViewController/MeetingListViewController.swift
@@ -87,7 +87,7 @@ extension MeetingListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let viewController = MeetingInfoViewController(
             viewModel: MeetingInfoViewModel(
-                meetingID: 1,
+                meetingID: viewModel.meetingList.value?.data?.meetings[indexPath.item].meetingID ?? 0,
                 service: MockMeetingInfoService()
             )
         )

--- a/KkuMulKum/Source/MeetingList/ViewController/MeetingListViewController.swift
+++ b/KkuMulKum/Source/MeetingList/ViewController/MeetingListViewController.swift
@@ -85,7 +85,6 @@ extension MeetingListViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // TODO: MeetingID를 넘겨받기
         let viewController = MeetingInfoViewController(
             viewModel: MeetingInfoViewModel(
                 meetingID: viewModel.meetingList.value?.data?.meetings[indexPath.item].meetingID ?? 0,

--- a/KkuMulKum/Source/Promise/ReadyStatus/ViewModel/SetReadyInfoViewModel.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/ViewModel/SetReadyInfoViewModel.swift
@@ -29,6 +29,16 @@ final class SetReadyInfoViewModel {
         }
     }
     
+    private func calculateTimes() {
+        let readyHours = Int(readyHour.value) ?? 0
+        let readyMinutes = Int(readyMinute.value) ?? 0
+        let moveHours = Int(moveHour.value) ?? 0
+        let moveMinutes = Int(moveMinute.value) ?? 0
+        
+        readyTime = readyHours * 60 + readyMinutes
+        moveTime = moveHours * 60 + moveMinutes
+    }
+    
     func updateTime(textField: String, time: String) {
         guard let time = Int(time) else { return }
         
@@ -44,6 +54,8 @@ final class SetReadyInfoViewModel {
         default:
             break
         }
+        
+        calculateTimes()
     }
     
     func checkValid(


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #213 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 홈 화면에서 오늘의 약속, 다가올 약속 화면 연결을 위해 `promiseID`를 전달하는 주석을 남겨두었습니다. (@youz2me)
- 내 모임 리스트에서 모임 상세로 들어가기 위해 `meetingID`를 전달합니다. (@JinUng41)
- 준비정보입력 ViewModel(= `SetReadyInfoViewModel`)에 정보를 입력할 때마다 준비/이동 시간을 분으로 계산하여 저장하도록 로직을 추가해두었습니다. `readyTime`과 `moveTime` 변수에 분 단위의 시간이 저장됩니다. 로컬 알림 구현 시 참고 부탁드립니다. (@hooni0918)
- 내 모임 리스트의 약속 추가 액션은 이후 유진이가 연결해주기로 했습니다! (@youz2me) ^-^

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
화면 연결이 처음이라 미숙한 점이 많습니다. 혹시 잘못된 부분이 있다면 피드백 부탁드립니다!
늘 감사합니다 ㅜ.ㅜ

**준비 정보 입력에 관한 화면 연결은 유진이 부분이 연결된 다음 진행할 예정입니다!**