### PR TITLE
[feat] 준비 정보 입력 화면 연결 및 API 연결

### DIFF
--- a/KkuMulKum.xcodeproj/project.pbxproj
+++ b/KkuMulKum.xcodeproj/project.pbxproj
@@ -47,9 +47,9 @@
 		785AE1BE2C2E878600677CA0 /* FirebaseStorageCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 785AE1BD2C2E878600677CA0 /* FirebaseStorageCombine-Community */; };
 		785AE1C02C2E878600677CA0 /* FirebaseVertexAI-Preview in Frameworks */ = {isa = PBXBuildFile; productRef = 785AE1BF2C2E878600677CA0 /* FirebaseVertexAI-Preview */; };
 		785AE1D12C3B07A600677CA0 /* PrivacyInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 785AE1D02C3B07A600677CA0 /* PrivacyInfo.plist */; };
+		789196342C486F6B00FF8CDF /* KeychainAccessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 789196332C486F6B00FF8CDF /* KeychainAccessible.swift */; };
 		789196362C492F8600FF8CDF /* AuthTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 789196352C492F8600FF8CDF /* AuthTargetType.swift */; };
 		789196382C49697B00FF8CDF /* AuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 789196372C49697B00FF8CDF /* AuthError.swift */; };
-		789196342C486F6B00FF8CDF /* KeychainAccessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 789196332C486F6B00FF8CDF /* KeychainAccessible.swift */; };
 		789873322C3D1A7B00435E96 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7898732F2C3D1A7B00435E96 /* LoginViewController.swift */; };
 		789873332C3D1A7B00435E96 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 789873302C3D1A7B00435E96 /* LoginViewModel.swift */; };
 		789873342C3D1A7B00435E96 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 789873312C3D1A7B00435E96 /* LoginView.swift */; };
@@ -72,6 +72,7 @@
 		A39F2B192C47BF83008DA5F5 /* SetReadyCompletedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39F2B182C47BF83008DA5F5 /* SetReadyCompletedView.swift */; };
 		A39F2B1B2C47C206008DA5F5 /* SetReadyCompletedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39F2B1A2C47C206008DA5F5 /* SetReadyCompletedViewController.swift */; };
 		A39F2B1D2C47F3D0008DA5F5 /* HomeTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39F2B1C2C47F3D0008DA5F5 /* HomeTargetType.swift */; };
+		A39F2B212C499CE5008DA5F5 /* SetReadyStatusInfoServiceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39F2B202C499CE5008DA5F5 /* SetReadyStatusInfoServiceType.swift */; };
 		A3DD9C3D2C41BAD000E58A13 /* MeetingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DD9C322C41BAD000E58A13 /* MeetingTableViewCell.swift */; };
 		A3DD9C3F2C41BAD000E58A13 /* MeetingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DD9C362C41BAD000E58A13 /* MeetingListView.swift */; };
 		A3DD9C402C41BAD000E58A13 /* MeetingListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DD9C382C41BAD000E58A13 /* MeetingListViewController.swift */; };
@@ -239,9 +240,9 @@
 		782B407E2C3E44B7008B0CA7 /* WelcomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeViewModel.swift; sourceTree = "<group>"; };
 		782B40812C3E4925008B0CA7 /* NicknameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameViewModel.swift; sourceTree = "<group>"; };
 		785AE1D02C3B07A600677CA0 /* PrivacyInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = PrivacyInfo.plist; sourceTree = "<group>"; };
+		789196332C486F6B00FF8CDF /* KeychainAccessible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainAccessible.swift; sourceTree = "<group>"; };
 		789196352C492F8600FF8CDF /* AuthTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthTargetType.swift; sourceTree = "<group>"; };
 		789196372C49697B00FF8CDF /* AuthError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthError.swift; sourceTree = "<group>"; };
-		789196332C486F6B00FF8CDF /* KeychainAccessible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainAccessible.swift; sourceTree = "<group>"; };
 		7898732F2C3D1A7B00435E96 /* LoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		789873302C3D1A7B00435E96 /* LoginViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		789873312C3D1A7B00435E96 /* LoginView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
@@ -266,6 +267,7 @@
 		A39F2B182C47BF83008DA5F5 /* SetReadyCompletedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetReadyCompletedView.swift; sourceTree = "<group>"; };
 		A39F2B1A2C47C206008DA5F5 /* SetReadyCompletedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetReadyCompletedViewController.swift; sourceTree = "<group>"; };
 		A39F2B1C2C47F3D0008DA5F5 /* HomeTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTargetType.swift; sourceTree = "<group>"; };
+		A39F2B202C499CE5008DA5F5 /* SetReadyStatusInfoServiceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetReadyStatusInfoServiceType.swift; sourceTree = "<group>"; };
 		A3DD9C322C41BAD000E58A13 /* MeetingTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeetingTableViewCell.swift; sourceTree = "<group>"; };
 		A3DD9C362C41BAD000E58A13 /* MeetingListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeetingListView.swift; sourceTree = "<group>"; };
 		A3DD9C382C41BAD000E58A13 /* MeetingListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeetingListViewController.swift; sourceTree = "<group>"; };
@@ -1039,6 +1041,7 @@
 			isa = PBXGroup;
 			children = (
 				DD86265D2C4606A300E4F980 /* MockReadyStatusService.swift */,
+				A39F2B202C499CE5008DA5F5 /* SetReadyStatusInfoServiceType.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -1768,6 +1771,7 @@
 				DED5DBF02C345317006ECE7E /* BaseCollectionViewCell.swift in Sources */,
 				DE32D1D42C3BFB56006848DF /* UpdateProfileNameModel.swift in Sources */,
 				DD3F9DD02C48571A008E1FF7 /* MeetingListServiceType.swift in Sources */,
+				A39F2B212C499CE5008DA5F5 /* SetReadyStatusInfoServiceType.swift in Sources */,
 				DE6D4D132C3F14D80005584B /* MeetingMemberCell.swift in Sources */,
 				DDAF1C932C3D6E3D008A37D3 /* PagePromiseViewController.swift in Sources */,
 				789D73BE2C47FE0F00C7077D /* AuthInterceptor.swift in Sources */,
@@ -1856,7 +1860,7 @@
 				DD4909962C440CDC003ED304 /* ArriveView.swift in Sources */,
 				DD86266A2C4606A300E4F980 /* MockReadyStatusService.swift in Sources */,
 				789196342C486F6B00FF8CDF /* KeychainAccessible.swift in Sources */,
-				DD86266A2C4606A300E4F980 /* ReadyStatusService.swift in Sources */,
+				DD86266A2C4606A300E4F980 /* MockReadyStatusService.swift in Sources */,
 				DE254AB02C31195B00A4015E /* NSAttributedString+.swift in Sources */,
 				DD43937B2C412F4500EC1799 /* CreateMeetingViewController.swift in Sources */,
 				DD86266C2C4606A300E4F980 /* SetReadyInfoViewController.swift in Sources */,

--- a/KkuMulKum/Network/TargetType/PromiseTargetType.swift
+++ b/KkuMulKum/Network/TargetType/PromiseTargetType.swift
@@ -20,7 +20,10 @@ enum PromiseTargetType {
     case fetchPromiseInfo(promiseID: Int)
     case fetchMyReadyStatus(promiseID: Int)
     case fetchPromiseParticipantList(promiseID: Int)
-    case updateMyPromiseReadyStatus(promiseID: Int)
+    case updateMyPromiseReadyStatus(
+        promiseID: Int,
+        requestModel: MyPromiseReadyInfoModel
+    )
     case fetchTardyInfo(promiseID: Int)
     case updatePromiseCompletion(promiseID: Int)
 }
@@ -57,7 +60,7 @@ extension PromiseTargetType: TargetType {
             return "/api/v1/promises/\(promiseID)/status"
         case .fetchPromiseParticipantList(let promiseID):
             return "/api/v1/promises/\(promiseID)/participants"
-        case .updateMyPromiseReadyStatus(let promiseID):
+        case .updateMyPromiseReadyStatus(let promiseID, _):
             return "/api/v1/promises/\(promiseID)/times"
         case .fetchTardyInfo(let promiseID):
             return "/api/v1/promises/\(promiseID)/tardy"
@@ -84,9 +87,11 @@ extension PromiseTargetType: TargetType {
         switch self {
         case .fetchTodayNextPromise, .fetchUpcomingPromiseList, .updatePreparationStatus,
                 .updateDepartureStatus, .updateArrivalStatus, .fetchPromiseInfo,
-                .fetchMyReadyStatus, .fetchPromiseParticipantList, .updateMyPromiseReadyStatus,
+                .fetchMyReadyStatus, .fetchPromiseParticipantList,
                 .fetchTardyInfo, .updatePromiseCompletion, .fetchMeetingPromiseList:
             return .requestPlain
+        case .updateMyPromiseReadyStatus(_, let request):
+            return .requestJSONEncodable(request)
         case .addPromise(_, let request):
             return .requestJSONEncodable(request)
         }

--- a/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
+++ b/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
@@ -18,8 +18,8 @@ class HomeViewController: BaseViewController {
     
     private let viewModel: HomeViewModel
     
-    final let cellWidth: CGFloat = Screen.width(200)
-    final let cellHeight: CGFloat = Screen.height(216)
+    final let cellWidth: CGFloat = 200
+    final let cellHeight: CGFloat = 216
     final let contentInterSpacing: CGFloat = 12
     final let contentInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
     
@@ -225,7 +225,7 @@ private extension HomeViewController {
                     color: .lightGreen
                 )
                 self?.rootView.levelLabel.setText(
-                    "Lv.\(data?.data?.level ?? 0) \(self?.viewModel.levelName.value ?? "")",
+                    "Lv.\(data?.data?.level ?? 0)  \(self?.viewModel.levelName.value ?? "")",
                     style: .caption01,
                     color: .gray6
                 )

--- a/KkuMulKum/Source/MeetingList/ViewModel/MeetingListViewModel.swift
+++ b/KkuMulKum/Source/MeetingList/ViewModel/MeetingListViewModel.swift
@@ -26,6 +26,5 @@ final class MeetingListViewModel {
                 print(">>> \(error.localizedDescription) : \(#function)")
             }
         }
-//        meetingList.value = service.fetchMeetingList()
     }
 }

--- a/KkuMulKum/Source/Promise/ReadyStatus/Service/SetReadyStatusInfoServiceType.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/Service/SetReadyStatusInfoServiceType.swift
@@ -1,0 +1,38 @@
+//
+//  SetReadyStatusInfoServiceType.swift
+//  KkuMulKum
+//
+//  Created by 예삐 on 7/19/24.
+//
+
+import Foundation
+
+protocol SetReadyStatusInfoServiceType {
+    func updateMyPromiseReadyStatus(
+        with promiseID: Int,
+        requestModel: MyPromiseReadyInfoModel
+    ) async throws -> ResponseBodyDTO<EmptyModel>?
+}
+
+extension PromiseService: SetReadyStatusInfoServiceType {
+    func updateMyPromiseReadyStatus(
+        with promiseID: Int,
+        requestModel: MyPromiseReadyInfoModel
+    ) async throws -> ResponseBodyDTO<EmptyModel>? {
+        return try await request(
+            with: .updateMyPromiseReadyStatus(
+                promiseID: promiseID,
+                requestModel: requestModel
+            )
+        )
+    }
+}
+
+final class MockSetReadyStatusInfoService: SetReadyStatusInfoServiceType {
+    func updateMyPromiseReadyStatus(
+        with promiseID: Int,
+        requestModel: MyPromiseReadyInfoModel
+    ) async throws -> ResponseBodyDTO<EmptyModel>? {
+        return ResponseBodyDTO(success: true, data: nil, error: nil)
+    }
+}

--- a/KkuMulKum/Source/Promise/ReadyStatus/View/SetReadyCompletedView.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/View/SetReadyCompletedView.swift
@@ -23,6 +23,7 @@ final class SetReadyCompletedView: BaseView {
     
     private let subtitleLabel = UILabel().then {
         $0.setText("설정하신 시간에 맞춰서\n준비 및 이동 시간에 알림을 울려 드릴게요", style: .body06, color: .gray6)
+        $0.textAlignment = .center
     }
     
     let confirmButton = CustomButton(title: "확인", isEnabled: true)

--- a/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/ViewController/ReadyStatusViewController.swift
@@ -39,13 +39,11 @@ class ReadyStatusViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        // TODO: 서버 통신해서 데이터 바인딩 필요
-        
-        DispatchQueue.main.async {
-            self.updateReadyInfoView(
-                flag: self.readyStatusViewModel.isReadyInfoEntered.value
-            )
-            self.rootView.ourReadyStatusCollectionView.reloadData()
+        // TODO: 서버 통신해서
+        readyStatusViewModel.isReadyInfoEntered.bind { [weak self] flag in
+            DispatchQueue.main.async {
+                self?.updateReadyInfoView(flag: flag)
+            }
         }
     }
     
@@ -102,7 +100,14 @@ class ReadyStatusViewController: BaseViewController {
     /// 눌렀을 때 준비 정보 입력하기 화면으로 넘어가도록 설정
     @objc
     func enterReadyButtonDidTapped() {
-        let setReadyInfoViewController = SetReadyInfoViewController()
+        // TODO: 유진이가 promiseID, promiseTime 를 전달하면 됩니다.
+        let setReadyInfoViewController = SetReadyInfoViewController(
+            viewModel: SetReadyInfoViewModel(
+                promiseID: 1,
+                promiseTime: "",
+                service: PromiseService()
+            )
+        )
         
         navigationController?.pushViewController(
             setReadyInfoViewController,

--- a/KkuMulKum/Source/Promise/ReadyStatus/ViewController/SetReadyCompletedViewController.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/ViewController/SetReadyCompletedViewController.swift
@@ -17,6 +17,7 @@ final class SetReadyCompletedViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        view.backgroundColor = .green1
         
         setupNavigationBarTitle(with: "준비 정보 입력하기")
         navigationItem.hidesBackButton = true

--- a/KkuMulKum/Source/Promise/ReadyStatus/ViewController/SetReadyCompletedViewController.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/ViewController/SetReadyCompletedViewController.swift
@@ -21,4 +21,21 @@ final class SetReadyCompletedViewController: BaseViewController {
         setupNavigationBarTitle(with: "준비 정보 입력하기")
         navigationItem.hidesBackButton = true
     }
+    
+    override func setupAction() {
+        rootView.confirmButton.addTarget(self, action: #selector(confirmButtonDidTap), for: .touchUpInside)
+    }
+}
+
+private extension SetReadyCompletedViewController {
+    @objc
+    func confirmButtonDidTap() {
+        guard let viewControllers = navigationController?.viewControllers else { return }
+        for viewController in viewControllers {
+            if let pagePromiseViewController = viewController as? PagePromiseViewController {
+                navigationController?.popToViewController(pagePromiseViewController, animated: true)
+                break
+            }
+        }
+    }
 }

--- a/KkuMulKum/Source/Promise/ReadyStatus/ViewController/SetReadyInfoViewController.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/ViewController/SetReadyInfoViewController.swift
@@ -13,8 +13,19 @@ final class SetReadyInfoViewController: BaseViewController {
     // MARK: - Property
     
     private let rootView = SetReadyInfoView()
-    private let viewModel = SetReadyInfoViewModel()
+    private let viewModel: SetReadyInfoViewModel
     
+    
+    // MARK: - Initializer
+    
+    init(viewModel: SetReadyInfoViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     // MARK: - LifeCycle
     
@@ -22,12 +33,6 @@ final class SetReadyInfoViewController: BaseViewController {
         super.viewWillAppear(animated)
         
         navigationController?.isNavigationBarHidden = false
-    }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        
-        navigationController?.isNavigationBarHidden = true
     }
     
     override func loadView() {
@@ -69,6 +74,11 @@ final class SetReadyInfoViewController: BaseViewController {
             action: #selector(textFieldDidChange),
             for: .editingChanged
         )
+        rootView.doneButton.addTarget(
+            self,
+            action: #selector(doneButtonDidTap),
+            for: .touchUpInside
+        )
     }
     
     @objc
@@ -79,6 +89,11 @@ final class SetReadyInfoViewController: BaseViewController {
             moveHourText: rootView.moveHourTextField.text ?? "",
             moveMinuteText: rootView.moveMinuteTextField.text ?? ""
         )
+    }
+    
+    @objc
+    private func doneButtonDidTap(_ sender: UIButton) {
+        viewModel.updateReadyInfo()
     }
 }
 
@@ -160,6 +175,18 @@ private extension SetReadyInfoViewController {
         viewModel.errMessage.bind { [weak self] err in
             if !err.isEmpty {
                 self?.showToast(err)
+            }
+        }
+        
+        viewModel.isSucceedToSave.bind { [weak self] _ in
+            if self?.viewModel.isSucceedToSave.value == true {
+                DispatchQueue.main.async {
+                    let viewController = SetReadyCompletedViewController()
+                    self?.navigationController?.pushViewController(
+                        viewController,
+                        animated: true
+                    )
+                }
             }
         }
     }

--- a/KkuMulKum/Source/Promise/ReadyStatus/ViewModel/SetReadyInfoViewModel.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/ViewModel/SetReadyInfoViewModel.swift
@@ -8,17 +8,33 @@
 import Foundation
 
 final class SetReadyInfoViewModel {
-    var isValid = ObservablePattern<Bool>(false)
-    var errMessage = ObservablePattern<String>("")
+    let promiseID: Int
+    let promiseTime: String
     
-    var readyHour = ObservablePattern<String>("")
-    var readyMinute = ObservablePattern<String>("")
-    var moveHour = ObservablePattern<String>("")
-    var moveMinute = ObservablePattern<String>("")
+    let isValid = ObservablePattern<Bool>(false)
+    let errMessage = ObservablePattern<String>("")
     
-    //TODO: 준비 및 이동 시간 분 단위로 계산
+    let readyHour = ObservablePattern<String>("")
+    let readyMinute = ObservablePattern<String>("")
+    let moveHour = ObservablePattern<String>("")
+    let moveMinute = ObservablePattern<String>("")
+    let isSucceedToSave = ObservablePattern<Bool>(false)
+    
+    // TODO: 준비 및 이동 시간 분 단위로 계산
     var readyTime: Int = 0
     var moveTime: Int = 0
+    
+    private let service: SetReadyStatusInfoServiceType
+    
+    init(
+        promiseID: Int,
+        promiseTime: String,
+        service: SetReadyStatusInfoServiceType
+    ) {
+        self.promiseID = promiseID
+        self.promiseTime = promiseTime
+        self.service = service
+    }
     
     private func validTime(time: Int, range: ClosedRange<Int>, defaultValue: String) -> String {
         if range.contains(time) {
@@ -64,11 +80,39 @@ final class SetReadyInfoViewModel {
         moveHourText: String,
         moveMinuteText: String
     ) {
-        if !readyHourText.isEmpty && !readyMinuteText.isEmpty 
+        if !readyHourText.isEmpty && !readyMinuteText.isEmpty
             && !moveHourText.isEmpty && !moveMinuteText.isEmpty {
             isValid.value = true
         } else {
             isValid.value = false
+        }
+    }
+    
+    func updateReadyInfo() {
+        // 확인 버튼이 눌렸을 때
+        // 1. 로컬 알림 만들기
+        // 2. 서버에 입력받은 거 전송하기
+        // TODO: 지훈이가 만들어준 로컬 알림 만드는 객체에 요청하기 <- 객체가 필요 <- 생성자 주입
+        /// 생성자 또는 메서드 전달인자 - promiseID, promiseTime, readyTime, moveTime
+        
+        Task {
+            let model = MyPromiseReadyInfoModel(
+                preparationTime: readyTime,
+                travelTime: moveTime
+            )
+            
+            do {
+                guard let responseBody = try await service.updateMyPromiseReadyStatus(
+                    with: promiseID,
+                    requestModel: model
+                ) else {
+                    isSucceedToSave.value = false
+                    return
+                }
+                isSucceedToSave.value = responseBody.success
+            } catch {
+                print(">>> \(error.localizedDescription) : \(#function)")
+            }
         }
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #235 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 준비 정보 입력 화면 연결을 진행했습니다. (준비 현황 -> 준비 정보 입력 -> 준비 정보 입력 완료 -> 다시 준비 현황으로 pop)
- 준비 정보 입력 화면에 PATCH API를 연결했습니다. 완료 버튼을 눌렀을 때 서버에 requestModel을 전달을 요청하고 isSucceed가 되면 다음 화면(완료 화면)으로 이동 및 로컬 알림을 호출합니다. (이때, reponseModel은 EmptyModel입니다.)
- 준비 정보 입력 완료 화면의 UI를 수정했습니다.

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 이후 준비 현황 화면에서 promiseTime을 전달해주세요. TODO 표시를 해두었습니다. (@youz2me)
- 준비 정보 입력 뷰모델(SetReadyInfoViewModel)의 updateReadyInfo()에서 로컬 알림을 구현해주시면 감사하겠습니다. 마찬가지로 TODO 표시를 해두었습니다. (@hooni0918) 아직 준비 현황의 서버 통신이 미완성인 상태라 ReadyStatusViewController에서 PromiseTime을 ""로 전달하고 있는 점 참고 부탁드립니다.