### PR TITLE
[fix] 네비게이션 Pop 제스처 해결

### DIFF
--- a/KkuMulKum/Resource/Base/BaseViewController.swift
+++ b/KkuMulKum/Resource/Base/BaseViewController.swift
@@ -19,6 +19,12 @@ class BaseViewController: UIViewController {
         setupDelegate()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        navigationController?.interactivePopGestureRecognizer?.delegate = self
+    }
+    
     /// 네비게이션 바 등 추가적으로 UI와 관련한 작업
     func setupView() {}
     
@@ -63,8 +69,13 @@ extension BaseViewController {
         ).then {
             $0.tintColor = .black
         }
-        
         navigationItem.leftBarButtonItem = backButton
+    }
+}
+
+extension BaseViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return navigationController?.viewControllers.count ?? 0 > 1
     }
 }
 


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #242 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 네비게이션 Pop 제스처 해결

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### UIGestureRecognizerDelegate
- leftBarButtonItem을 추가하는 순간, 제스처 동작하지 않는 문제를 확인함. (블로그를 통해)
- 네비게이션 컨트롤러의 팝 제스처 델리게이트 할당
- 네비게이션 컨트롤러의 배열을 검사 (하나일 때는 제스처 실행 false)

<details>
<summary>BaseViewController.swift</summary>

```swift
// BaseViewController 내에서
override func viewWillAppear(_ animated: Bool) {
    super.viewWillAppear(animated)
    
    navigationController?.interactivePopGestureRecognizer?.delegate = self
}

extension BaseViewController: UIGestureRecognizerDelegate {
    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
        return navigationController?.viewControllers.count ?? 0 > 1
    }
}
```
</details>

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- https://gyuios.tistory.com/147