### PR TITLE
[feat] 준비/이동/도착 시간 업데이트 API 및 준비 현황 API 연결

### DIFF
--- a/KkuMulKum/Application/SceneDelegate.swift
+++ b/KkuMulKum/Application/SceneDelegate.swift
@@ -36,7 +36,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 DispatchQueue.main.async {
                     if success {
                         print("Auto login successful, showing main screen")
-                        self?.showLoginScreen()
+                        self?.showMainScreen()
                     } else {
                         print("Auto login failed, showing login screen")
                         self?.showLoginScreen()

--- a/KkuMulKum/Network/DTO/Model/Promises/MyReadyStatusResponseModel.swift
+++ b/KkuMulKum/Network/DTO/Model/Promises/MyReadyStatusResponseModel.swift
@@ -12,9 +12,9 @@ import Foundation
 
 struct MyReadyStatusModel: ResponseModelType {
     let promiseTime: String
-    let preparationTime: Int
-    let travelTime: Int
-    let preparationStartAt: String
-    let departureAt: String
-    let arrivalAt: String
+    let preparationTime: Int?
+    let travelTime: Int?
+    let preparationStartAt: String?
+    let departureAt: String?
+    let arrivalAt: String?
 }

--- a/KkuMulKum/Network/TargetType/HomeTargetType.swift
+++ b/KkuMulKum/Network/TargetType/HomeTargetType.swift
@@ -16,6 +16,7 @@ enum HomeTargetType {
     case updatePreparationStatus(promiseID: Int)
     case updateDepartureStatus(promiseID: Int)
     case updateArrivalStatus(promiseID: Int)
+    case fetchMyReadyStatus(promiseID: Int)
 }
 
 extension HomeTargetType: TargetType {
@@ -42,12 +43,14 @@ extension HomeTargetType: TargetType {
             return "/api/v1/promises/\(promiseID)/departure"
         case .updateArrivalStatus(let promiseID):
             return "/api/v1/promises/\(promiseID)/arrival"
+        case .fetchMyReadyStatus(let promiseID):
+            return "/api/v1/promises/\(promiseID)/status"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .fetchLoginUser, .fetchNearestPromise, .fetchUpcomingPromise:
+        case .fetchLoginUser, .fetchNearestPromise, .fetchUpcomingPromise, .fetchMyReadyStatus:
             return .get
         case .updatePreparationStatus, .updateDepartureStatus, .updateArrivalStatus:
             return .patch

--- a/KkuMulKum/Source/Home/ServiceType/HomeServiceType.swift
+++ b/KkuMulKum/Source/Home/ServiceType/HomeServiceType.swift
@@ -13,6 +13,7 @@ protocol HomeServiceType {
     func fetchLoginUser() async throws -> ResponseBodyDTO<LoginUserModel>?
     func fetchNearestPromise() async throws -> ResponseBodyDTO<NearestPromiseModel>?
     func fetchUpcomingPromise() async throws -> ResponseBodyDTO<UpcomingPromiseListModel>?
+    func fetchMyReadyStatus(with promiseID: Int) async throws -> ResponseBodyDTO<MyReadyStatusModel>?
     
     func updatePreparationStatus(with promiseID: Int) async throws -> ResponseBodyDTO<EmptyModel>?
     func updateDepartureStatus(with promiseID: Int) async throws -> ResponseBodyDTO<EmptyModel>?
@@ -20,6 +21,10 @@ protocol HomeServiceType {
 }
 
 extension HomeService: HomeServiceType {
+    func fetchMyReadyStatus(with promiseID: Int) async throws -> ResponseBodyDTO<MyReadyStatusModel>? {
+        return try await request(with: .fetchMyReadyStatus(promiseID: promiseID))
+    }
+    
     func updatePreparationStatus(with promiseID: Int) async throws -> ResponseBodyDTO<EmptyModel>? {
         return try await request(
             with: .updatePreparationStatus(promiseID: promiseID)
@@ -52,6 +57,10 @@ extension HomeService: HomeServiceType {
 }
 
 final class MockHomeService: HomeServiceType {
+    func fetchMyReadyStatus(with promiseID: Int) async throws -> ResponseBodyDTO<MyReadyStatusModel>? {
+        return nil
+    }
+    
     func updatePreparationStatus(with promiseID: Int) async throws -> ResponseBodyDTO<EmptyModel>? {
         return nil
     }

--- a/KkuMulKum/Source/Home/ServiceType/HomeServiceType.swift
+++ b/KkuMulKum/Source/Home/ServiceType/HomeServiceType.swift
@@ -13,9 +13,31 @@ protocol HomeServiceType {
     func fetchLoginUser() async throws -> ResponseBodyDTO<LoginUserModel>?
     func fetchNearestPromise() async throws -> ResponseBodyDTO<NearestPromiseModel>?
     func fetchUpcomingPromise() async throws -> ResponseBodyDTO<UpcomingPromiseListModel>?
+    
+    func updatePreparationStatus(with promiseID: Int) async throws -> ResponseBodyDTO<EmptyModel>?
+    func updateDepartureStatus(with promiseID: Int) async throws -> ResponseBodyDTO<EmptyModel>?
+    func updateArrivalStatus(with promiseID: Int) async throws -> ResponseBodyDTO<EmptyModel>?
 }
 
 extension HomeService: HomeServiceType {
+    func updatePreparationStatus(with promiseID: Int) async throws -> ResponseBodyDTO<EmptyModel>? {
+        return try await request(
+            with: .updatePreparationStatus(promiseID: promiseID)
+        )
+    }
+    
+    func updateDepartureStatus(with promiseID: Int) async throws -> ResponseBodyDTO<EmptyModel>? {
+        return try await request(
+            with: .updateDepartureStatus(promiseID: promiseID)
+        )
+    }
+    
+    func updateArrivalStatus(with promiseID: Int) async throws -> ResponseBodyDTO<EmptyModel>? {
+        return try await request(
+            with: .updateArrivalStatus(promiseID: promiseID)
+        )
+    }
+    
     func fetchLoginUser() async throws -> ResponseBodyDTO<LoginUserModel>? {
         return try await request(with: .fetchLoginUser)
     }
@@ -30,6 +52,18 @@ extension HomeService: HomeServiceType {
 }
 
 final class MockHomeService: HomeServiceType {
+    func updatePreparationStatus(with promiseID: Int) async throws -> ResponseBodyDTO<EmptyModel>? {
+        return nil
+    }
+    
+    func updateDepartureStatus(with promiseID: Int) async throws -> ResponseBodyDTO<EmptyModel>? {
+        return nil
+    }
+    
+    func updateArrivalStatus(with promiseID: Int) async throws -> ResponseBodyDTO<EmptyModel>? {
+        return nil
+    }
+    
     func fetchLoginUser() async throws -> ResponseBodyDTO<LoginUserModel>? {
         let mockData = ResponseBodyDTO<LoginUserModel>(
             success: true,

--- a/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
+++ b/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
@@ -58,18 +58,10 @@ class HomeViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.isNavigationBarHidden = true
-        
-//        updateUserInfo()
-//        updateNearestPromise()
-//        updateUpcomingPromise()
-//        updateUI()
-        
+
         viewModel.requestLoginUser()
         viewModel.requestNearestPromise()
         viewModel.requestUpcomingPromise()
-//        viewModel.requestMyReadyStatus()
-        
-//        bindViewModel()
     }
     
     override func setupAction() {
@@ -195,47 +187,6 @@ private extension HomeViewController {
             forCellWithReuseIdentifier: UpcomingPromiseCollectionViewCell.reuseIdentifier
         )
     }
-    
-//    func bindViewModel() {
-//        viewModel.isPreapreSucceedToSave.bind { [weak self] _ in
-//            if self?.viewModel.isPreapreSucceedToSave.value == true {
-//                DispatchQueue.main.async {
-//                    //self?.setPrepareUI()
-//                    self?.rootView.todayPromiseView.prepareTimeLabel.setText(
-//                        self?.viewModel.homePrepareTime ?? "",
-//                        style: .caption02,
-//                        color: .gray8
-//                    )
-//                }
-//            }
-//        }
-//        
-//        viewModel.isMoveSucceedToSave.bind { [weak self] _ in
-//            if self?.viewModel.isMoveSucceedToSave.value == true {
-//                DispatchQueue.main.async {
-//                    //self?.setMoveUI()
-//                    self?.rootView.todayPromiseView.moveTimeLabel.setText(
-//                        self?.viewModel.homeMoveTime ?? "",
-//                        style: .caption02,
-//                        color: .gray8
-//                    )
-//                }
-//            }
-//        }
-//        
-//        viewModel.isArriveSucceedToSave.bind { [weak self] _ in
-//            if self?.viewModel.isArriveSucceedToSave.value == true {
-//                DispatchQueue.main.async {
-//                    //self?.setArriveUI()
-//                    self?.rootView.todayPromiseView.arriveTimeLabel.setText(
-//                        self?.viewModel.homeArriveTime ?? "",
-//                        style: .caption02,
-//                        color: .gray8
-//                    )
-//                }
-//            }
-//        }
-//    }
     
     func updateUI() {
         viewModel.currentState.bind { [weak self] state in

--- a/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
+++ b/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
@@ -48,15 +48,21 @@ class HomeViewController: BaseViewController {
         view.backgroundColor = .maincolor
         register()
         
+        updateUI()
+        
         updateUserInfo()
         updateNearestPromise()
         updateUpcomingPromise()
-        updateUI()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.isNavigationBarHidden = true
+        
+//        updateUserInfo()
+//        updateNearestPromise()
+//        updateUpcomingPromise()
+//        updateUI()
         
         viewModel.requestLoginUser()
         viewModel.requestNearestPromise()
@@ -397,6 +403,7 @@ private extension HomeViewController {
         setProgressButton(rootView.todayPromiseView.moveButton)
         setEnableButton(rootView.todayPromiseView.arriveButton)
         
+        rootView.todayPromiseView.prepareButton.isEnabled = false
         rootView.todayPromiseView.moveButton.isEnabled = false
         rootView.todayPromiseView.arriveButton.isEnabled = true
         
@@ -425,6 +432,7 @@ private extension HomeViewController {
         setCompleteButton(rootView.todayPromiseView.moveButton)
         setCompleteButton(rootView.todayPromiseView.arriveButton)
         
+        rootView.todayPromiseView.prepareButton.isEnabled = false
         rootView.todayPromiseView.moveButton.isEnabled = false
         rootView.todayPromiseView.arriveButton.isEnabled = false
         

--- a/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
+++ b/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
@@ -51,17 +51,19 @@ class HomeViewController: BaseViewController {
         updateUserInfo()
         updateNearestPromise()
         updateUpcomingPromise()
-        
-        viewModel.requestLoginUser()
-        viewModel.requestNearestPromise()
-        viewModel.requestUpcomingPromise()
-        
-        bindViewModel()
+        updateUI()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.isNavigationBarHidden = true
+        
+        viewModel.requestLoginUser()
+        viewModel.requestNearestPromise()
+        viewModel.requestUpcomingPromise()
+        viewModel.requestMyReadyStatus()
+        
+//        bindViewModel()
     }
     
     override func setupAction() {
@@ -188,42 +190,59 @@ private extension HomeViewController {
         )
     }
     
-    func bindViewModel() {
-        viewModel.isPreapreSucceedToSave.bind { [weak self] _ in
-            if self?.viewModel.isPreapreSucceedToSave.value == true {
-                DispatchQueue.main.async {
+//    func bindViewModel() {
+//        viewModel.isPreapreSucceedToSave.bind { [weak self] _ in
+//            if self?.viewModel.isPreapreSucceedToSave.value == true {
+//                DispatchQueue.main.async {
+//                    //self?.setPrepareUI()
+//                    self?.rootView.todayPromiseView.prepareTimeLabel.setText(
+//                        self?.viewModel.homePrepareTime ?? "",
+//                        style: .caption02,
+//                        color: .gray8
+//                    )
+//                }
+//            }
+//        }
+//        
+//        viewModel.isMoveSucceedToSave.bind { [weak self] _ in
+//            if self?.viewModel.isMoveSucceedToSave.value == true {
+//                DispatchQueue.main.async {
+//                    //self?.setMoveUI()
+//                    self?.rootView.todayPromiseView.moveTimeLabel.setText(
+//                        self?.viewModel.homeMoveTime ?? "",
+//                        style: .caption02,
+//                        color: .gray8
+//                    )
+//                }
+//            }
+//        }
+//        
+//        viewModel.isArriveSucceedToSave.bind { [weak self] _ in
+//            if self?.viewModel.isArriveSucceedToSave.value == true {
+//                DispatchQueue.main.async {
+//                    //self?.setArriveUI()
+//                    self?.rootView.todayPromiseView.arriveTimeLabel.setText(
+//                        self?.viewModel.homeArriveTime ?? "",
+//                        style: .caption02,
+//                        color: .gray8
+//                    )
+//                }
+//            }
+//        }
+//    }
+    
+    func updateUI() {
+        viewModel.currentState.bind { [weak self] state in
+            DispatchQueue.main.async {
+                switch state {
+                case .prepare:
                     self?.setPrepareUI()
-                    self?.rootView.todayPromiseView.prepareTimeLabel.setText(
-                        self?.viewModel.homePrepareTime ?? "",
-                        style: .caption02,
-                        color: .gray8
-                    )
-                }
-            }
-        }
-        
-        viewModel.isMoveSucceedToSave.bind { [weak self] _ in
-            if self?.viewModel.isMoveSucceedToSave.value == true {
-                DispatchQueue.main.async {
+                case .move:
                     self?.setMoveUI()
-                    self?.rootView.todayPromiseView.moveTimeLabel.setText(
-                        self?.viewModel.homeMoveTime ?? "",
-                        style: .caption02,
-                        color: .gray8
-                    )
-                }
-            }
-        }
-        
-        viewModel.isArriveSucceedToSave.bind { [weak self] _ in
-            if self?.viewModel.isArriveSucceedToSave.value == true {
-                DispatchQueue.main.async {
+                case .arrive:
                     self?.setArriveUI()
-                    self?.rootView.todayPromiseView.arriveTimeLabel.setText(
-                        self?.viewModel.homeArriveTime ?? "",
-                        style: .caption02,
-                        color: .gray8
-                    )
+                case .none:
+                    break
                 }
             }
         }
@@ -366,6 +385,10 @@ private extension HomeViewController {
         rootView.todayPromiseView.moveLabel.isHidden = false
         
         rootView.todayPromiseView.prepareLineView.isHidden = false
+        
+        rootView.todayPromiseView.prepareTimeLabel.setText(
+            self.viewModel.myReadyStatus.value?.data?.preparationStartAt ?? "", style: .caption02, color: .gray8
+        )
     }
     
     func setMoveUI() {
@@ -385,7 +408,16 @@ private extension HomeViewController {
         rootView.todayPromiseView.arriveLabel.isHidden = false
         
         rootView.todayPromiseView.prepareCheckView.isHidden = false
+        
+        rootView.todayPromiseView.prepareLineView.isHidden = false
         rootView.todayPromiseView.moveLineView.isHidden = false
+        
+        rootView.todayPromiseView.prepareTimeLabel.setText(
+            self.viewModel.myReadyStatus.value?.data?.preparationStartAt ?? "", style: .caption02, color: .gray8
+        )
+        rootView.todayPromiseView.moveTimeLabel.setText(
+            self.viewModel.myReadyStatus.value?.data?.departureAt ?? "", style: .caption02, color: .gray8
+        )
     }
     
     func setArriveUI() {
@@ -404,9 +436,23 @@ private extension HomeViewController {
         rootView.todayPromiseView.moveLabel.isHidden = true
         rootView.todayPromiseView.arriveLabel.isHidden = true
         
+        rootView.todayPromiseView.prepareCheckView.isHidden = false
         rootView.todayPromiseView.moveCheckView.isHidden = false
         rootView.todayPromiseView.arriveCheckView.isHidden = false
+        
+        rootView.todayPromiseView.prepareLineView.isHidden = false
+        rootView.todayPromiseView.moveLineView.isHidden = false
         rootView.todayPromiseView.arriveLineView.isHidden = false
+        
+        rootView.todayPromiseView.prepareTimeLabel.setText(
+            self.viewModel.myReadyStatus.value?.data?.preparationStartAt ?? "", style: .caption02, color: .gray8
+        )
+        rootView.todayPromiseView.moveTimeLabel.setText(
+            self.viewModel.myReadyStatus.value?.data?.departureAt ?? "", style: .caption02, color: .gray8
+        )
+        rootView.todayPromiseView.arriveTimeLabel.setText(
+            self.viewModel.myReadyStatus.value?.data?.arrivalAt ?? "", style: .caption02, color: .gray8
+        )
     }
     
     

--- a/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
+++ b/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
@@ -48,8 +48,6 @@ class HomeViewController: BaseViewController {
         view.backgroundColor = .maincolor
         register()
         
-        updateUI()
-        
         updateUserInfo()
         updateNearestPromise()
         updateUpcomingPromise()
@@ -57,6 +55,8 @@ class HomeViewController: BaseViewController {
         viewModel.requestLoginUser()
         viewModel.requestNearestPromise()
         viewModel.requestUpcomingPromise()
+        
+        bindViewModel()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -188,17 +188,43 @@ private extension HomeViewController {
         )
     }
     
-    func updateUI() {
-        viewModel.currentState.bind { [weak self] state in
-            switch state {
-            case .prepare:
-                self?.setPrepareUI()
-            case .move:
-                self?.setMoveUI()
-            case .arrive:
-                self?.setArriveUI()
-            case .none:
-                break
+    func bindViewModel() {
+        viewModel.isPreapreSucceedToSave.bind { [weak self] _ in
+            if self?.viewModel.isPreapreSucceedToSave.value == true {
+                DispatchQueue.main.async {
+                    self?.setPrepareUI()
+                    self?.rootView.todayPromiseView.prepareTimeLabel.setText(
+                        self?.viewModel.homePrepareTime ?? "",
+                        style: .caption02,
+                        color: .gray8
+                    )
+                }
+            }
+        }
+        
+        viewModel.isMoveSucceedToSave.bind { [weak self] _ in
+            if self?.viewModel.isMoveSucceedToSave.value == true {
+                DispatchQueue.main.async {
+                    self?.setMoveUI()
+                    self?.rootView.todayPromiseView.moveTimeLabel.setText(
+                        self?.viewModel.homeMoveTime ?? "",
+                        style: .caption02,
+                        color: .gray8
+                    )
+                }
+            }
+        }
+        
+        viewModel.isArriveSucceedToSave.bind { [weak self] _ in
+            if self?.viewModel.isArriveSucceedToSave.value == true {
+                DispatchQueue.main.async {
+                    self?.setArriveUI()
+                    self?.rootView.todayPromiseView.arriveTimeLabel.setText(
+                        self?.viewModel.homeArriveTime ?? "",
+                        style: .caption02,
+                        color: .gray8
+                    )
+                }
             }
         }
     }
@@ -402,31 +428,16 @@ private extension HomeViewController {
     
     @objc
     func prepareButtonDidTap(_ sender: UIButton) {
-        viewModel.updateState(newState: .prepare)
-        rootView.todayPromiseView.prepareTimeLabel.setText(
-            viewModel.homePrepareTime,
-            style: .caption02,
-            color: .gray8
-        )
+        viewModel.updatePrepareStatus()
     }
     
     @objc
     func moveButtonDidTap(_ sender: UIButton) {
-        viewModel.updateState(newState: .move)
-        rootView.todayPromiseView.moveTimeLabel.setText(
-            viewModel.homeMoveTime,
-            style: .caption02,
-            color: .gray8
-        )
+        viewModel.updateMoveStatus()
     }
     
     @objc
     func arriveButtonDidTap(_ sender: UIButton) {
-        viewModel.updateState(newState: .arrive)
-        rootView.todayPromiseView.arriveTimeLabel.setText(
-            viewModel.homeArriveTime,
-            style: .caption02,
-            color: .gray8
-        )
+        viewModel.updateArriveStatus()
     }
 }

--- a/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
+++ b/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
@@ -67,7 +67,7 @@ class HomeViewController: BaseViewController {
         viewModel.requestLoginUser()
         viewModel.requestNearestPromise()
         viewModel.requestUpcomingPromise()
-        viewModel.requestMyReadyStatus()
+//        viewModel.requestMyReadyStatus()
         
 //        bindViewModel()
     }

--- a/KkuMulKum/Source/Home/ViewModel/HomeViewModel.swift
+++ b/KkuMulKum/Source/Home/ViewModel/HomeViewModel.swift
@@ -27,40 +27,11 @@ final class HomeViewModel {
     var levelName = ObservablePattern<String>("")
     var levelCaption = ObservablePattern<String>("")
     
-    var isPreapreSucceedToSave = ObservablePattern<Bool>(false)
-    var isMoveSucceedToSave = ObservablePattern<Bool>(false)
-    var isArriveSucceedToSave = ObservablePattern<Bool>(false)
-    
     private let service: HomeServiceType
     
     init(service: HomeServiceType) {
         self.service = service
     }
-    
-//    var homePrepareTime: String = ""
-//    var homeMoveTime: String = ""
-//    var homeArriveTime: String = ""
-    
-//    private let dateFormatter = DateFormatter().then {
-//        $0.dateFormat = "a hh:mm"
-//        $0.amSymbol = "AM"
-//        $0.pmSymbol = "PM"
-//    }
-    
-//    private func updateState(newState: ReadyState) {
-//        currentState.value = newState
-//        let currentTimeString = dateFormatter.string(from: Date())
-//        switch newState {
-//        case .prepare:
-//            homePrepareTime = currentTimeString
-//        case .move:
-//            homeMoveTime = currentTimeString
-//        case .arrive:
-//            homeArriveTime = currentTimeString
-//        case .none:
-//            break
-//        }
-//    }
     
     ///서버에서 보내주는 level Int 값에 따른 levelName
     private func getLevelName(level: Int) -> String {
@@ -124,10 +95,8 @@ final class HomeViewModel {
                     with: nearestPromise.value?.data?.promiseID ?? 1
                 ) 
                 else {
-                    isPreapreSucceedToSave.value = false
                     return
                 }
-                isPreapreSucceedToSave.value = responseBody.success
                 currentState.value = .prepare
             } catch {
                 print(">>> \(error.localizedDescription) : \(#function)")
@@ -142,10 +111,8 @@ final class HomeViewModel {
                     with: nearestPromise.value?.data?.promiseID ?? 1
                 ) 
                 else {
-                    isMoveSucceedToSave.value = false
                     return
                 }
-                isMoveSucceedToSave.value = responseBody.success
                 currentState.value = .move
             } catch {
                 print(">>> \(error.localizedDescription) : \(#function)")
@@ -160,10 +127,8 @@ final class HomeViewModel {
                     with: nearestPromise.value?.data?.promiseID ?? 1
                 )
                 else {
-                    isArriveSucceedToSave.value = false
                     return
                 }
-                isArriveSucceedToSave.value = responseBody.success
                 currentState.value = .arrive
             } catch {
                 print(">>> \(error.localizedDescription) : \(#function)")

--- a/KkuMulKum/Source/Home/ViewModel/HomeViewModel.swift
+++ b/KkuMulKum/Source/Home/ViewModel/HomeViewModel.swift
@@ -187,6 +187,7 @@ final class HomeViewModel {
         Task  {
             do {
                 nearestPromise.value = try await service.fetchNearestPromise()
+                requestMyReadyStatus()
             } catch {
                 print(">>> \(error.localizedDescription) : \(#function)")
             }

--- a/KkuMulKum/Source/Home/ViewModel/HomeViewModel.swift
+++ b/KkuMulKum/Source/Home/ViewModel/HomeViewModel.swift
@@ -17,11 +17,12 @@ enum ReadyState {
 }
 
 final class HomeViewModel {
-    var promiseID = ObservablePattern<Int>?(nil)
+    var currentState = ObservablePattern<ReadyState>(.none)
     
     var loginUser = ObservablePattern<ResponseBodyDTO<LoginUserModel>?>(nil)
     var nearestPromise = ObservablePattern<ResponseBodyDTO<NearestPromiseModel>?>(nil)
     var upcomingPromiseList = ObservablePattern<ResponseBodyDTO<UpcomingPromiseListModel>?>(nil)
+    var myReadyStatus = ObservablePattern<ResponseBodyDTO<MyReadyStatusModel>?>(nil)
     
     var levelName = ObservablePattern<String>("")
     var levelCaption = ObservablePattern<String>("")
@@ -36,32 +37,33 @@ final class HomeViewModel {
         self.service = service
     }
     
-    var homePrepareTime: String = ""
-    var homeMoveTime: String = ""
-    var homeArriveTime: String = ""
+//    var homePrepareTime: String = ""
+//    var homeMoveTime: String = ""
+//    var homeArriveTime: String = ""
     
-    private let dateFormatter = DateFormatter().then {
-        $0.dateFormat = "a hh:mm"
-        $0.amSymbol = "AM"
-        $0.pmSymbol = "PM"
-    }
+//    private let dateFormatter = DateFormatter().then {
+//        $0.dateFormat = "a hh:mm"
+//        $0.amSymbol = "AM"
+//        $0.pmSymbol = "PM"
+//    }
     
-    private func updateState(newState: ReadyState) {
-        let currentTimeString = dateFormatter.string(from: Date())
-        switch newState {
-        case .prepare:
-            homePrepareTime = currentTimeString
-        case .move:
-            homeMoveTime = currentTimeString
-        case .arrive:
-            homeArriveTime = currentTimeString
-        case .none:
-            break
-        }
-    }
+//    private func updateState(newState: ReadyState) {
+//        currentState.value = newState
+//        let currentTimeString = dateFormatter.string(from: Date())
+//        switch newState {
+//        case .prepare:
+//            homePrepareTime = currentTimeString
+//        case .move:
+//            homeMoveTime = currentTimeString
+//        case .arrive:
+//            homeArriveTime = currentTimeString
+//        case .none:
+//            break
+//        }
+//    }
     
     ///서버에서 보내주는 level Int 값에 따른 levelName
-    func getLevelName(level: Int) -> String {
+    private func getLevelName(level: Int) -> String {
         switch level {
             case 1: return "빼꼼 꾸물이"
             case 2: return "밍기적 꾸물이"
@@ -72,7 +74,7 @@ final class HomeViewModel {
     }
     
     ///서버에서 보내주는 level Int 값에 따른 levelCaption
-    func getLevelCaption(level: Int) -> String {
+    private func getLevelCaption(level: Int) -> String {
         switch level {
         case 1:
             return "꾸물꿈에 오신 것을 환영해요!\n정시 도착으로 캐릭터를 성장시켜 보세요."
@@ -87,16 +89,46 @@ final class HomeViewModel {
         }
     }
     
+    private func judgeReadyStatus() {
+        let data = myReadyStatus.value?.data
+        if data?.preparationStartAt == nil && data?.departureAt == nil && data?.arrivalAt == nil {
+            currentState.value = .none
+        } else if data?.preparationStartAt != nil && data?.departureAt == nil && data?.arrivalAt == nil {
+            currentState.value = .prepare
+        } else if data?.departureAt != nil && data?.arrivalAt == nil {
+            currentState.value = .move
+        } else if data?.arrivalAt != nil {
+            currentState.value = .arrive
+        }
+    }
+    
+    func requestMyReadyStatus() {
+        Task  {
+            do {
+                print(currentState.value)
+                myReadyStatus.value = try await service.fetchMyReadyStatus(
+                    with: nearestPromise.value?.data?.promiseID ?? 1
+                )
+                judgeReadyStatus()
+                print(currentState.value)
+            } catch {
+                print(">>> \(error.localizedDescription) : \(#function)")
+            }
+        }
+    }
+    
     func updatePrepareStatus() {
         Task {
             do {
-                guard let responseBody = try await service.updatePreparationStatus(with: nearestPromise.value?.data?.promiseID ?? 1) 
+                guard let responseBody = try await service.updatePreparationStatus(
+                    with: nearestPromise.value?.data?.promiseID ?? 1
+                ) 
                 else {
                     isPreapreSucceedToSave.value = false
                     return
                 }
                 isPreapreSucceedToSave.value = responseBody.success
-                updateState(newState: .prepare)
+//                updateState(newState: .prepare)
             } catch {
                 print(">>> \(error.localizedDescription) : \(#function)")
             }
@@ -106,13 +138,15 @@ final class HomeViewModel {
     func updateMoveStatus() {
         Task {
             do {
-                guard let responseBody = try await service.updateDepartureStatus(with: nearestPromise.value?.data?.promiseID ?? 1) 
+                guard let responseBody = try await service.updateDepartureStatus(
+                    with: nearestPromise.value?.data?.promiseID ?? 1
+                ) 
                 else {
                     isMoveSucceedToSave.value = false
                     return
                 }
                 isMoveSucceedToSave.value = responseBody.success
-                updateState(newState: .move)
+//                updateState(newState: .move)
             } catch {
                 print(">>> \(error.localizedDescription) : \(#function)")
             }
@@ -122,13 +156,15 @@ final class HomeViewModel {
     func updateArriveStatus() {
         Task {
             do {
-                guard let responseBody = try await service.updateArrivalStatus(with: nearestPromise.value?.data?.promiseID ?? 1)
+                guard let responseBody = try await service.updateArrivalStatus(
+                    with: nearestPromise.value?.data?.promiseID ?? 1
+                )
                 else {
                     isArriveSucceedToSave.value = false
                     return
                 }
                 isArriveSucceedToSave.value = responseBody.success
-                updateState(newState: .arrive)
+//                updateState(newState: .arrive)
             } catch {
                 print(">>> \(error.localizedDescription) : \(#function)")
             }

--- a/KkuMulKum/Source/Home/ViewModel/HomeViewModel.swift
+++ b/KkuMulKum/Source/Home/ViewModel/HomeViewModel.swift
@@ -128,7 +128,7 @@ final class HomeViewModel {
                     return
                 }
                 isPreapreSucceedToSave.value = responseBody.success
-//                updateState(newState: .prepare)
+                currentState.value = .prepare
             } catch {
                 print(">>> \(error.localizedDescription) : \(#function)")
             }
@@ -146,7 +146,7 @@ final class HomeViewModel {
                     return
                 }
                 isMoveSucceedToSave.value = responseBody.success
-//                updateState(newState: .move)
+                currentState.value = .move
             } catch {
                 print(">>> \(error.localizedDescription) : \(#function)")
             }
@@ -164,7 +164,7 @@ final class HomeViewModel {
                     return
                 }
                 isArriveSucceedToSave.value = responseBody.success
-//                updateState(newState: .arrive)
+                currentState.value = .arrive
             } catch {
                 print(">>> \(error.localizedDescription) : \(#function)")
             }

--- a/KkuMulKum/Source/Promise/ReadyStatus/ViewModel/SetReadyInfoViewModel.swift
+++ b/KkuMulKum/Source/Promise/ReadyStatus/ViewModel/SetReadyInfoViewModel.swift
@@ -20,7 +20,6 @@ final class SetReadyInfoViewModel {
     let moveMinute = ObservablePattern<String>("")
     let isSucceedToSave = ObservablePattern<Bool>(false)
     
-    // TODO: 준비 및 이동 시간 분 단위로 계산
     var readyTime: Int = 0
     var moveTime: Int = 0
     


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #241 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 준비/이동/도착 시간 업데이트 API를 연결합니다.
- 준비 현황 API를 연결합니다. 준비 현황 데이터의 시간에 따라 현재 준비 상태를 분기 처리하고, 해당 준비 상태에 맞는 UI를 관리합니다.

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 현재는 준비 버튼을 눌렀을 때 다른 페이지를 다녀 와야 UI가 업데이트 됩니다. 이후 수정하겠습니다.