### PR TITLE
[fix] 홈 화면 엠티뷰 처리 로직 변경

### DIFF
--- a/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
+++ b/KkuMulKum/Source/Home/ViewController/HomeViewController.swift
@@ -290,11 +290,15 @@ private extension HomeViewController {
     
     func updateUpcomingPromise() {
         viewModel.upcomingPromiseList.bind { [weak self] _ in
+            guard let self,
+                  let responseBody = viewModel.upcomingPromiseList.value,
+                  let data = responseBody.data
+            else {
+                return
+            }
+            
             DispatchQueue.main.async {
-                guard let self = self else { return }
-                let data = self.viewModel.nearestPromise.value
-                
-                if data?.data == nil {
+                if data.promises.isEmpty {
                     self.rootView.upcomingPromiseView.isHidden = true
                     self.rootView.upcomingEmptyView.isHidden = false
                 } else {


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #258 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 홈 화면 엠티뷰 로직 수정

|    구현 내용    |   IPhone 15 pro   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/f31be0fd-67ed-4e22-b999-de444d1303ba" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 엠티뷰 처리 로직
- 네트워크 통신에 성공하면 배열에 접근하여 요소의 개수가 0인지 아닌지에 따라 엠티뷰 로직 처리
