### PR TITLE
[fix] 프로필 이미지가 흐려지는 현상 수정 및 이미지 설정 코드 간결화

### DIFF
--- a/KkuMulKum/Source/AddPromise/Cell/PlaceListCell.swift
+++ b/KkuMulKum/Source/AddPromise/Cell/PlaceListCell.swift
@@ -117,12 +117,14 @@ extension PlaceListCell {
 private extension PlaceListCell {
     func configureCell(title: String, roadAddress: String?, address: String?) {
         titleLabel.setText(title, style: .body05, color: .gray8)
+        
         roadAddressNameLabel.setText(
             roadAddress ?? " ",
             style: .caption02,
             color: .gray6,
             isSingleLine: true
         )
+        
         addressNameLabel.setText(
             address ?? " ",
             style: .caption02,

--- a/KkuMulKum/Source/AddPromise/Cell/SelectMemberCell.swift
+++ b/KkuMulKum/Source/AddPromise/Cell/SelectMemberCell.swift
@@ -63,8 +63,8 @@ extension SelectMemberCell {
         self.member = member
         
         nameLabel.setText(member.name ?? " ", style: .body06, color: .gray6)
-        profileImageView.image = .imgProfile.withRenderingMode(.alwaysOriginal)
-        guard let imageURL = URL(string: member.profileImageURL ?? "") else { return }
-        profileImageView.kf.setImage(with: imageURL)
+        
+        let imageURL = member.profileImageURL.flatMap { URL(string: $0) }
+        profileImageView.kf.setImage(with: imageURL, placeholder: UIImage.imgProfile.withRenderingMode(.alwaysOriginal))
     }
 }

--- a/KkuMulKum/Source/MeetingInfo/Cell/MeetingMemberCell.swift
+++ b/KkuMulKum/Source/MeetingInfo/Cell/MeetingMemberCell.swift
@@ -17,7 +17,6 @@ protocol MeetingMemberCellDelegate: AnyObject {
 
 final class MeetingMemberCell: BaseCollectionViewCell {
     private let profileImageButton = UIButton().then {
-        $0.backgroundColor = .gray2
         $0.layer.cornerRadius = Screen.height(64) / 2
         $0.isEnabled = false
         $0.clipsToBounds = true
@@ -35,7 +34,7 @@ final class MeetingMemberCell: BaseCollectionViewCell {
         
         profileImageButton.do {
             $0.imageView?.image = nil
-            $0.backgroundColor = .gray2
+            $0.backgroundColor = .clear
             $0.isEnabled = false
         }
         
@@ -100,21 +99,15 @@ private extension MeetingMemberCell {
     
     func configureForProfile(with member: Member) {
         let name = member.name
-        let imageURL = member.profileImageURL
+        let imageURL = member.profileImageURL.flatMap { URL(string: $0) }
         
         nameLabel.setText(name ?? " ", style: .caption02, color: .gray6)
-        profileImageButton.setImage(
-            .imgProfile.withRenderingMode(.alwaysOriginal),
-            for: .normal
-        )
         
-        setProfileImage(urlString: imageURL ?? "")
-    }
-    
-    func setProfileImage(urlString: String) {
-        guard let url = URL(string: urlString) else { return }
-
-        profileImageButton.kf.setImage(with: url, for: .normal)
+        profileImageButton.kf.setImage(
+            with: imageURL,
+            for: .disabled,
+            placeholder: .imgProfile.withRenderingMode(.alwaysOriginal)
+        )
     }
     
     @objc


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #280 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 이미지가 흐려진 현상 수정
- 이미지 설정 코드를 간결하게 수정

|    구현 내용    |   IPhone 11 pro max   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/f1ebe434-ce55-46fe-acb1-d4a5d580eeb6" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 왜 이미지가 흐려졌는가
- 현재 버튼으로 구현되있는데, `isEnabled = false`일 경우 흐려지는 원인을 발견하였고
- 이미지 설정을 `disabled`일 때 설정하는 것으로서, 흐려지는 현상을 수정할 수 있었습니다.

<details>
<summary>MeetingMemberCell.swift</summary>

```swift
profileImageButton.kf.setImage(
    with: imageURL,
    for: .disabled,
    placeholder: .imgProfile.withRenderingMode(.alwaysOriginal)
)
```
</details>