### PR TITLE
[refactor] 커스텀 액션 시트 액션 버튼 분기 처리

### DIFF
--- a/KkuMulKum/Resource/Component/CustomActionSheetController.swift
+++ b/KkuMulKum/Resource/Component/CustomActionSheetController.swift
@@ -14,7 +14,7 @@ import Then
 
 protocol CustomActionSheetDelegate: AnyObject {
     /// CustomActionSheetController의 ActionButton이 눌렸을 때, 어떤 작업을 할 지 정의합니다.
-    func actionButtonDidTap()
+    func actionButtonDidTap(for kind: ActionSheetKind)
 }
 
 final class CustomActionSheetController: BaseViewController {
@@ -113,7 +113,7 @@ final class CustomActionSheetController: BaseViewController {
     override func setupAction() {
         actionButton.rx.tap
             .subscribe(with: self) { owner, _ in
-                owner.delegate?.actionButtonDidTap()
+                owner.delegate?.actionButtonDidTap(for: owner.kind)
                 owner.dismiss(animated: true)
             }
             .disposed(by: disposeBag)
@@ -123,95 +123,6 @@ final class CustomActionSheetController: BaseViewController {
                 owner.dismiss(animated: true)
             }
             .disposed(by: disposeBag)
-    }
-}
-
-
-// MARK: - ActionSheetKind
-
-extension CustomActionSheetController {
-    enum ActionSheetKind {
-        case exitMeeting
-        case exitPromise
-        case deletePromise
-        case logout
-        case unsubscribe
-        
-        var image: UIImage? {
-            switch self {
-            case .exitMeeting:
-                    .imgExitMeeting
-            case .exitPromise:
-                    .imgExitPromise
-            case .deletePromise:
-                    .imgDeletePromise
-            case .logout, .unsubscribe:
-                nil
-            }
-        }
-        
-        var imageHeight: CGFloat {
-            switch self {
-            case .exitMeeting:
-                Screen.height(90)
-            case .exitPromise, .deletePromise:
-                Screen.height(86)
-            case .logout, .unsubscribe:
-                0
-            }
-        }
-        
-        var title: String {
-            switch self {
-            case .exitMeeting:
-                "모임에서 나가시겠어요?"
-            case .exitPromise:
-                "약속에서 나가시겠어요?"
-            case .deletePromise:
-                "정말 약속을 삭제하시겠어요?"
-            case .logout:
-                "로그아웃 하시겠어요?"
-            case .unsubscribe:
-                "정말 탈퇴 하시겠어요?"
-            }
-        }
-        
-        var description: String {
-            switch self {
-            case .exitMeeting:
-                "모임에서 나가도\n초대 코드를 통해 다시 들어올 수 있어요."
-            case .exitPromise:
-                "약속에서 나가도\n참여 인원 추가를 통해 다시 참여 가능해요."
-            case .deletePromise:
-                "약속을 삭제하면 해당 약속이\n모든 참여 인원의 약속 목록에서 사라져요."
-            case .logout:
-                "로그아웃 시, 다시 로그인 하셔야 해요."
-            case .unsubscribe:
-                "탈퇴 버튼 선택시,\n계정은 삭제되며 복구되지 않습니다."
-            }
-        }
-        
-        var descriptionColor: UIColor {
-            switch self {
-            case .exitMeeting, .exitPromise, .logout:
-                    .gray6
-            case .deletePromise, .unsubscribe:
-                    .red
-            }
-        }
-        
-        var actionButtonTitle: String {
-            switch self {
-            case .exitMeeting, .exitPromise:
-                "나가기"
-            case .deletePromise:
-                "삭제하기"
-            case .logout:
-                "로그아웃"
-            case .unsubscribe:
-                "탈퇴하기"
-            }
-        }
     }
 }
 
@@ -246,6 +157,95 @@ private extension CustomActionSheetController {
             $0.bottom.equalTo(labelStackView.snp.top).offset(-32)
             $0.centerX.equalToSuperview()
             $0.height.equalTo(kind.imageHeight)
+        }
+    }
+}
+
+
+// MARK: - ActionSheetKind
+
+enum ActionSheetKind {
+    case exitMeeting
+    case exitPromise
+    case deletePromise
+    case logout
+    case unsubscribe
+}
+
+fileprivate extension ActionSheetKind {
+    var image: UIImage? {
+        switch self {
+        case .exitMeeting:
+                .imgExitMeeting
+        case .exitPromise:
+                .imgExitPromise
+        case .deletePromise:
+                .imgDeletePromise
+        case .logout, .unsubscribe:
+            nil
+        }
+    }
+    
+    var imageHeight: CGFloat {
+        switch self {
+        case .exitMeeting:
+            Screen.height(90)
+        case .exitPromise, .deletePromise:
+            Screen.height(86)
+        case .logout, .unsubscribe:
+            0
+        }
+    }
+    
+    var title: String {
+        switch self {
+        case .exitMeeting:
+            "모임에서 나가시겠어요?"
+        case .exitPromise:
+            "약속에서 나가시겠어요?"
+        case .deletePromise:
+            "정말 약속을 삭제하시겠어요?"
+        case .logout:
+            "로그아웃 하시겠어요?"
+        case .unsubscribe:
+            "정말 탈퇴 하시겠어요?"
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .exitMeeting:
+            "모임에서 나가도\n초대 코드를 통해 다시 들어올 수 있어요."
+        case .exitPromise:
+            "약속에서 나가도\n참여 인원 추가를 통해 다시 참여 가능해요."
+        case .deletePromise:
+            "약속을 삭제하면 해당 약속이\n모든 참여 인원의 약속 목록에서 사라져요."
+        case .logout:
+            "로그아웃 시, 다시 로그인 하셔야 해요."
+        case .unsubscribe:
+            "탈퇴 버튼 선택시,\n계정은 삭제되며 복구되지 않습니다."
+        }
+    }
+    
+    var descriptionColor: UIColor {
+        switch self {
+        case .exitMeeting, .exitPromise, .logout:
+                .gray6
+        case .deletePromise, .unsubscribe:
+                .red
+        }
+    }
+    
+    var actionButtonTitle: String {
+        switch self {
+        case .exitMeeting, .exitPromise:
+            "나가기"
+        case .deletePromise:
+            "삭제하기"
+        case .logout:
+            "로그아웃"
+        case .unsubscribe:
+            "탈퇴하기"
         }
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #310

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 외부에서 정의되는 delegate 메서드가 kind에 따라 분기처리가 가능하도록 메서드 수정

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### CustomActionSheetDelegate
- `actionButtonDidTap`이 눌렸을 때, `kind`에 따른 분기처리가 가능하도록 인자를 추가
- 이 때, 외부에서 `kind`를 알기 때문에 불필요한 내용은 `fileprivate extension`을 통해 은닉화했습니다.

<details>
<summary>CustomActionSheetController.swift</summary>

```swift
protocol CustomActionSheetDelegate: AnyObject {
    /// CustomActionSheetController의 ActionButton이 눌렸을 때, 어떤 작업을 할 지 정의합니다.
    func actionButtonDidTap(for kind: ActionSheetKind)
}

/// 실제 외부에서 사용 시
extension ViewController: CustomActionSheetDelegate {
    func actionButtonDidTap(for kind: ActionSheetKind) {
        if kind == .deletePromise {
            // 하고자 하는 작업
        }
    }
}
```
</details>