### PR TITLE
[refactor] CALayer를 이용한 네비게이션 바 경계선 설정 구현

### DIFF
--- a/KkuMulKum/Resource/Extension/UINavigationController+.swift
+++ b/KkuMulKum/Resource/Extension/UINavigationController+.swift
@@ -7,21 +7,6 @@
 
 import UIKit
 
-import SnapKit
-import Then
-
-extension UINavigationController {
-    fileprivate static let borderLine = UIView(backgroundColor: .gray2)
-    
-    func hideBorder() {
-        Self.borderLine.isHidden = true
-    }
-    
-    func showBorder() {
-        Self.borderLine.isHidden = false
-    }
-}
-
 extension UINavigationController {
     convenience init(rootViewController: UIViewController, isBorderNeeded: Bool) {
         self.init(rootViewController: rootViewController)
@@ -31,16 +16,40 @@ extension UINavigationController {
         }
     }
     
-    private func addBorder() {
-        let border = Self.borderLine
+    func showBorder() {
+        let border = findBottomBorder()
+        border?.isHidden = false
+    }
+    
+    func hideBorder() {
+        let border = findBottomBorder()
+        border?.isHidden = true
+    }
+}
+
+private extension UINavigationController {
+    enum Constants {
+        static let bottomBorderName = "BottomBorder"
+        static let bottomBorderWidth: CGFloat = Screen.height(1)
+    }
+    
+    func addBorder() {
+        guard findBottomBorder() == nil else { return }
         
-        if !navigationBar.subviews.contains(where: { $0 == border }) {
-            navigationBar.addSubviews(border)
-            
-            border.snp.makeConstraints {
-                $0.horizontalEdges.bottom.equalToSuperview()
-                $0.height.equalTo(Screen.height(1))
-            }
-        }
+        let border = CALayer()
+        border.name = Constants.bottomBorderName
+        border.backgroundColor = UIColor.gray2.cgColor
+        border.frame = CGRect(
+            x: 0,
+            y: navigationBar.frame.height - Constants.bottomBorderWidth,
+            width: navigationBar.frame.width,
+            height: Constants.bottomBorderWidth
+        )
+        
+        navigationBar.layer.addSublayer(border)
+    }
+    
+    func findBottomBorder() -> CALayer? {
+        return navigationBar.layer.sublayers?.first(where: { $0.name == Constants.bottomBorderName })
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #313

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 싱글톤 인스턴스의 단점을 극복
- CALayer를 이용한 하단 경계선 설정

### 기존의 싱글톤 인스턴스인 Border
- 저는 개인적으로 싱글톤 인스턴스를 지양합니다.
- 앱이 시작함과 동시에 인스턴스가 메모리의 힙 영역에 생성되어, 앱이 종료될 때까지 유지됩니다.
- 또한 기존의 구현은 여러 UINavigationController의 인스턴스가 하나의 Border 인스턴스를 참조하기 때문에, 예기치 못한 동작을 야기할 수도 있습니다.

```mermaid
classDiagram

NavigationController1 --> Border : 참조
NavigationController2 --> Border : 참조
NavigationController3 --> Border : 참조
```

- 위와 같은 상황에서의 문제점은 border에 대해서 수정 (isHidden 처리 등)이 발생하면, 참조하고 있는 다른 곳에서도 영향을 받을 수 있습니다.
- 따라서 아래와 같이 개선하였습니다.

```mermaid
classDiagram

NavigationController1 --> Border1 : 소유
NavigationController2 --> Border2 : 소유
NavigationController3 --> Border3 : 소유
```
- 위와 같이 구현하게 되면, 각각의 경계선에 대한 수정이 독립적으로 수행될 수 있어 side-effect를 방지할 수 있습니다.

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### CALayer를 활용한 네비게이션 바 경계선 설정
- UIView 클래스의 `layer` 역시 CALayer로 동작하기 때문에 여기서 힌트를 얻었습니다.
- CALayer에는 이름을 부여할 수 있기 때문에, 이름을 부여하여, `sublayers` 배열로부터 경계선에 사용되는 인스턴스를 찾을 수 있도록 하였습니다.
- 해당 영역은 `private extension`으로 선언하여 외부에서 접근하지 못하도록 하였습니다.

<details>
<summary>UINavigationController+.swift</summary>

```swift
private extension UINavigationController {
    enum Constants {
        static let bottomBorderName = "BottomBorder"
        static let bottomBorderWidth: CGFloat = Screen.height(1)
    }
    
    func addBorder() {
        guard findBottomBorder() == nil else { return }
        
        let border = CALayer()
        border.name = Constants.bottomBorderName
        border.backgroundColor = UIColor.gray2.cgColor
        border.frame = CGRect(
            x: 0,
            y: navigationBar.frame.height - Constants.bottomBorderWidth,
            width: navigationBar.frame.width,
            height: Constants.bottomBorderWidth
        )
        
        navigationBar.layer.addSublayer(border)
    }
    
    func findBottomBorder() -> CALayer? {
        return navigationBar.layer.sublayers?.first(where: { $0.name == Constants.bottomBorderName })
    }
}
```
</details>