### PR TITLE
[feat] 약속 추가 플로우 변경된 기능 명세 반영하기

### DIFF
--- a/KkuMulKum/Source/AddPromise/View/AddPromiseCompleteView.swift
+++ b/KkuMulKum/Source/AddPromise/View/AddPromiseCompleteView.swift
@@ -58,9 +58,9 @@ final class AddPromiseCompleteView: BaseView {
         }
         
         progressView.snp.makeConstraints {
-            $0.top.equalTo(safeArea).offset(-2)
+            $0.top.equalTo(safeArea).offset(-1)
             $0.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(Screen.height(3))
+            $0.height.equalTo(Screen.height(4))
         }
         
         completionImageView.snp.makeConstraints {

--- a/KkuMulKum/Source/AddPromise/View/AddPromiseView.swift
+++ b/KkuMulKum/Source/AddPromise/View/AddPromiseView.swift
@@ -127,9 +127,9 @@ final class AddPromiseView: BaseView {
         let safeArea = safeAreaLayoutGuide
         
         progressView.snp.makeConstraints {
-            $0.top.equalTo(safeArea).offset(-2)
+            $0.top.equalTo(safeArea).offset(-1)
             $0.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(Screen.height(3))
+            $0.height.equalTo(Screen.height(4))
         }
         
         descriptionStackView.snp.makeConstraints {

--- a/KkuMulKum/Source/AddPromise/View/SelectMemberView.swift
+++ b/KkuMulKum/Source/AddPromise/View/SelectMemberView.swift
@@ -84,9 +84,9 @@ final class SelectMemberView: BaseView {
         let safeArea = safeAreaLayoutGuide
         
         progressView.snp.makeConstraints {
-            $0.top.equalTo(safeArea).offset(-2)
+            $0.top.equalTo(safeArea).offset(-1)
             $0.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(Screen.height(3))
+            $0.height.equalTo(Screen.height(4))
         }
         
         descriptionStackView.snp.makeConstraints {

--- a/KkuMulKum/Source/AddPromise/View/SelectMemberView.swift
+++ b/KkuMulKum/Source/AddPromise/View/SelectMemberView.swift
@@ -46,14 +46,36 @@ final class SelectMemberView: BaseView {
         )
     }
     
+    private let emptyImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFill
+        $0.image = .imgEmptyTardy.withRenderingMode(.alwaysOriginal)
+    }
+    
+    private let emptyLabel = UILabel().then {
+        $0.setText(
+            "약속에 함께할 꾸물이들이 없어요!\n모임에 친구들을 초대해보세요",
+            style: .body05,
+            color: .gray3
+        )
+        $0.textAlignment = .center
+    }
+    
+    let emptyContentView = UIStackView(axis: .vertical).then {
+        $0.spacing = 32
+        $0.alignment = .center
+        $0.isHidden = true
+    }
+    
     let confirmButton = CustomButton(title: "다음", isEnabled: true)
     
     override func setupView() {
         descriptionStackView.addArrangedSubviews(pageNumberLabel, titleLabel)
+        emptyContentView.addArrangedSubviews(emptyImageView, emptyLabel)
         addSubviews(
             progressView,
             descriptionStackView,
             memberListView,
+            emptyContentView,
             confirmButton
         )
     }
@@ -76,6 +98,16 @@ final class SelectMemberView: BaseView {
             $0.top.equalTo(descriptionStackView.snp.bottom).offset(16)
             $0.horizontalEdges.equalToSuperview().inset(20)
             $0.bottom.equalToSuperview().offset(-167)
+        }
+        
+        emptyImageView.snp.makeConstraints {
+            $0.width.equalTo(Screen.width(112))
+            $0.height.equalTo(Screen.height(122))
+        }
+        
+        emptyContentView.snp.makeConstraints {
+            $0.top.equalTo(descriptionStackView.snp.bottom).offset(130)
+            $0.horizontalEdges.equalToSuperview().inset(84)
         }
         
         confirmButton.snp.makeConstraints {

--- a/KkuMulKum/Source/AddPromise/View/SelectMemberView.swift
+++ b/KkuMulKum/Source/AddPromise/View/SelectMemberView.swift
@@ -46,7 +46,7 @@ final class SelectMemberView: BaseView {
         )
     }
     
-    let confirmButton = CustomButton(title: "다음")
+    let confirmButton = CustomButton(title: "다음", isEnabled: true)
     
     override func setupView() {
         descriptionStackView.addArrangedSubviews(pageNumberLabel, titleLabel)

--- a/KkuMulKum/Source/AddPromise/View/SelectPenaltyView.swift
+++ b/KkuMulKum/Source/AddPromise/View/SelectPenaltyView.swift
@@ -70,9 +70,9 @@ final class SelectPenaltyView: BaseView {
         let safeArea = safeAreaLayoutGuide
         
         progressView.snp.makeConstraints {
-            $0.top.equalTo(safeArea).offset(-2)
+            $0.top.equalTo(safeArea).offset(-1)
             $0.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(Screen.height(3))
+            $0.height.equalTo(Screen.height(4))
         }
         
         descriptionStackView.snp.makeConstraints {

--- a/KkuMulKum/Source/AddPromise/ViewController/SelectMemberViewController.swift
+++ b/KkuMulKum/Source/AddPromise/ViewController/SelectMemberViewController.swift
@@ -103,5 +103,13 @@ private extension SelectMemberViewController {
                 cell.configure(with: member)
             }
             .disposed(by: disposeBag)
+        
+        output.memberList
+            .map { $0.isEmpty }
+            .drive(with: self) { owner, flag in
+                owner.rootView.memberListView.isHidden = flag
+                owner.rootView.emptyContentView.isHidden = !flag
+            }
+            .disposed(by: disposeBag)
     }
 }

--- a/KkuMulKum/Source/AddPromise/ViewController/SelectMemberViewController.swift
+++ b/KkuMulKum/Source/AddPromise/ViewController/SelectMemberViewController.swift
@@ -103,11 +103,5 @@ private extension SelectMemberViewController {
                 cell.configure(with: member)
             }
             .disposed(by: disposeBag)
-        
-        output.isEnabledConfirmButton
-            .drive(with: self) { owner, flag in
-                owner.rootView.confirmButton.isEnabled = flag
-            }
-            .disposed(by: disposeBag)
     }
 }

--- a/KkuMulKum/Source/AddPromise/ViewModel/AddPromiseViewModel.swift
+++ b/KkuMulKum/Source/AddPromise/ViewModel/AddPromiseViewModel.swift
@@ -103,7 +103,6 @@ extension AddPromiseViewModel: ViewModelType {
         let adjustedDate = Observable.combineLatest(input.date, input.time)
             .map { date, time -> Date in
                 let calendar = Calendar.current
-                var combinedComponents = DateComponents()
                 
                 guard let tempDate = calendar.date(byAdding: .minute, value: -1, to: Date()) else {
                     return Date()

--- a/KkuMulKum/Source/AddPromise/ViewModel/SelectMemberViewModel.swift
+++ b/KkuMulKum/Source/AddPromise/ViewModel/SelectMemberViewModel.swift
@@ -74,13 +74,8 @@ extension SelectMemberViewModel: ViewModelType {
             }
             .disposed(by: disposeBag)
         
-        let isEnabledConfirmButton = selectedMemberListRelay
-            .map { !$0.isEmpty }
-            .asDriver(onErrorJustReturn: false)
-        
         let output = Output(
-            memberList: memberListRelay.asDriver(onErrorJustReturn: []),
-            isEnabledConfirmButton: isEnabledConfirmButton
+            memberList: memberListRelay.asDriver(onErrorJustReturn: [])
         )
         
         return output
@@ -91,9 +86,7 @@ private extension SelectMemberViewModel {
     func fetchMeetingMembers() {
         Task {
             do {
-                guard let responseBody = try await service.fetchMeetingMemberListExcludeLoginUser(
-                    with: meetingID
-                ),
+                guard let responseBody = try await service.fetchMeetingMemberListExcludeLoginUser(with: meetingID),
                       responseBody.success
                 else {
                     memberListRelay.accept([])

--- a/KkuMulKum/Source/AddPromise/ViewModel/SelectMemberViewModel.swift
+++ b/KkuMulKum/Source/AddPromise/ViewModel/SelectMemberViewModel.swift
@@ -47,7 +47,6 @@ extension SelectMemberViewModel: ViewModelType {
     
     struct Output {
         let memberList: Driver<[Member]>
-        let isEnabledConfirmButton: Driver<Bool>
     }
     
     func transform(input: Input, disposeBag: DisposeBag) -> Output {

--- a/KkuMulKum/Source/MeetingInfo/ViewController/MeetingInfoViewController.swift
+++ b/KkuMulKum/Source/MeetingInfo/ViewController/MeetingInfoViewController.swift
@@ -66,6 +66,14 @@ final class MeetingInfoViewController: BaseViewController {
         setupNavigationBarBackButton()
     }
     
+    override func setupAction() {
+        rootView.createPromiseButtonDidTap
+            .subscribe(with: self) { owner, _ in
+                owner.navigateToAddPromise()
+            }
+            .disposed(by: disposeBag)
+    }
+    
     override func setupDelegate() {
         rootView.promiseListView.delegate = self
     }
@@ -143,22 +151,6 @@ private extension MeetingInfoViewController {
                     time: promise.time,
                     place: promise.placeName
                 )
-            }
-            .disposed(by: disposeBag)
-        
-        output.isPossbleToCreatePromise
-            .drive(with: self) { owner, flag in
-                guard flag else {
-                    let toast = Toast()
-                    toast.show(
-                        message: "모임에 구성원이 없어서 약속을 만들 수 없어요.",
-                        view: owner.view,
-                        position: .bottom,
-                        inset: 100
-                    )
-                    return
-                }
-                owner.navigateToAddPromise()
             }
             .disposed(by: disposeBag)
     }

--- a/KkuMulKum/Source/MeetingInfo/ViewModel/MeetingInfoViewModel.swift
+++ b/KkuMulKum/Source/MeetingInfo/ViewModel/MeetingInfoViewModel.swift
@@ -38,7 +38,6 @@ extension MeetingInfoViewModel: ViewModelType {
         let memberCount: Driver<Int>
         let members: Driver<[Member]>
         let promises: Driver<[MeetingPromise]>
-        let isPossbleToCreatePromise: Driver<Bool>
     }
     
     func transform(input: Input, disposeBag: DisposeBag) -> Output {
@@ -74,25 +73,12 @@ extension MeetingInfoViewModel: ViewModelType {
                 return model.promises
             }
             .asDriver(onErrorJustReturn: [])
-        
-        let isPossibleToCreatePromise = input.createPromiseButtonDidTap
-            .map { [weak self] _ in
-                guard let count = self?.meetingMemberModelRelay.value?.memberCount,
-                      count > 1
-                else {
-                    return false
-                }
-                return true
-            }
-            .asDriver(onErrorJustReturn: false)
             
-        
         let output = Output(
             info: info,
             memberCount: memberCount,
             members: members,
-            promises: promises,
-            isPossbleToCreatePromise: isPossibleToCreatePromise
+            promises: promises
         )
         
         return output


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #312 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 약속 추가 플로우에서 기능 명세가 바뀐 부분을 반영하였습니다.
    1. 모임 구성원이 혼자임에도 약속 생성 가능
    2. 그에 따른 참여 인원 선택 화면에서 엠티뷰 처리

- 현재 모임 상세 화면등 사용되는 모델(DTO)에 대한 변경이 반영이 되지 않아 해당 동작 화면은 생략하였습니다만, MoyaPlugin을 이용한 print 디버깅을 통해 정상적으로 생성되는 것을 확인하였습니다.

|    구현 내용    |   IPhone 13 mini   |
| :-------------: | :----------: |
| 약속 생성 | <img src = "https://github.com/user-attachments/assets/6bfe515d-978b-4405-9c65-2023c997eca4" width ="250"> |