### PR TITLE
feat/#350 카카오로그인 구현완료

### DIFF
--- a/KkuMulKum.xcodeproj/project.pbxproj
+++ b/KkuMulKum.xcodeproj/project.pbxproj
@@ -1213,13 +1213,6 @@
 			path = Tardy;
 			sourceTree = "<group>";
 		};
-		DD9F59642C7C7E3B00E928DF /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = "Recovered References";
-			sourceTree = "<group>";
-		};
 		DD9F59652C7C7E5C00E928DF /* Cell */ = {
 			isa = PBXGroup;
 			children = (

--- a/KkuMulKum.xcodeproj/xcshareddata/xcschemes/KkuMulKum.xcscheme
+++ b/KkuMulKum.xcodeproj/xcshareddata/xcschemes/KkuMulKum.xcscheme
@@ -30,7 +30,7 @@
       shouldAutocreateTestPlan = "YES">
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -49,6 +49,13 @@
             ReferencedContainer = "container:KkuMulKum.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "IDEPreferLogStreaming"
+            value = "YES"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/KkuMulKum/Application/SceneDelegate.swift
+++ b/KkuMulKum/Application/SceneDelegate.swift
@@ -39,12 +39,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-        if let url = URLContexts.first?.url {
-            if (AuthApi.isKakaoTalkLoginUrl(url)) {
-                _ = AuthController.handleOpenUrl(url: url)
+            if let url = URLContexts.first?.url {
+                if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                    _ = AuthController.handleOpenUrl(url: url)
+                }
             }
         }
-    }
     
     func application(
         _ app: UIApplication,

--- a/KkuMulKum/Source/Onboarding/Login/VIewModel/LoginViewModel.swift
+++ b/KkuMulKum/Source/Onboarding/Login/VIewModel/LoginViewModel.swift
@@ -10,6 +10,7 @@ import AuthenticationServices
 
 import KakaoSDKUser
 import KakaoSDKAuth
+import KakaoSDKCommon
 import Moya
 import FirebaseMessaging
 
@@ -29,6 +30,8 @@ class LoginViewModel: NSObject {
     private let authInterceptor: AuthInterceptor
     private let keychainAccessible: KeychainAccessible
     
+    private let kakaoAppKey: String
+
     init(
         provider: MoyaProvider<AuthTargetType> = MoyaProvider<AuthTargetType>(
             plugins: [NetworkLoggerPlugin(configuration: .init(logOptions: .verbose))]
@@ -36,6 +39,12 @@ class LoginViewModel: NSObject {
         authService: AuthServiceProtocol = AuthService(),
         keychainAccessible: KeychainAccessible = DefaultKeychainAccessible()
     ) {
+        if let appKey = Bundle.main.privacyInfo?["NATIVE_APP_KEY"] as? String {
+            self.kakaoAppKey = appKey
+        } else {
+            fatalError("Failed to load NATIVE_APP_KEY from PrivacyInfo.plist")
+        }
+        
         self.provider = provider
         self.authService = authService
         self.authInterceptor = AuthInterceptor(authService: authService, provider: provider)


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #350 

## 📄 작업 내용
- 카카오 로그인 원래대로 돌려놓기

## 👀 기타 더 이야기해볼 점
url Type에 있던 앱 키 정보를 privacy 로 이전하고 기존 키를 지웟는데 appdelegate와 scenedelegete에서 이전 앱키를 받아오는 키로 사용하고있어서 생긴 오류였습니다. 꽤나 오래 안되고 있었을텐데 테스트로그인하느라 못본 모양이네요 모쪼록 해결햇습니다.
