### PR TITLE
[fix] 모임 상세 화면 QA 반영하기

### DIFF
--- a/KkuMulKum/Source/MeetingInfo/Cell/MeetingMemberCell.swift
+++ b/KkuMulKum/Source/MeetingInfo/Cell/MeetingMemberCell.swift
@@ -33,6 +33,9 @@ final class MeetingMemberCell: BaseCollectionViewCell {
         super.prepareForReuse()
         
         profileImageButton.do {
+            var config = UIButton.Configuration.plain()
+            config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+            
             $0.imageView?.image = nil
             $0.backgroundColor = .clear
             $0.isEnabled = false
@@ -89,6 +92,10 @@ private extension MeetingMemberCell {
         self.delegate = delegate
         
         profileImageButton.do {
+            var config = UIButton.Configuration.plain()
+            config.contentInsets = NSDirectionalEdgeInsets(top: 5, leading: 0, bottom: 0, trailing: 0)
+            
+            $0.configuration = config
             $0.backgroundColor = .gray1
             $0.setImage(.iconPlus.withTintColor(.gray4), for: .normal)
             $0.isEnabled = true

--- a/KkuMulKum/Source/MeetingInfo/View/MeetingInfoBannerView.swift
+++ b/KkuMulKum/Source/MeetingInfo/View/MeetingInfoBannerView.swift
@@ -15,7 +15,9 @@ final class MeetingInfoBannerView: BaseView {
         $0.setText("모임 생성일", style: .label01, color: .gray4)
     }
     
-    private let divider = UIView(backgroundColor: .gray4)
+    private let divider = UILabel().then {
+        $0.setText("l", style: .label01, color: .gray4)
+    }
     
     private let createdAtLabel = UILabel().then {
         $0.setText("2024.06.01", style: .label01, color: .gray4)
@@ -40,24 +42,29 @@ final class MeetingInfoBannerView: BaseView {
         backgroundColor = .lightGreen
         layer.cornerRadius = 8
         
-        horizontalStackView.addArrangedSubviews(explanationLabel, divider, createdAtLabel)
-        backgroundImageView.addSubviews(horizontalStackView, metCountLabel)
+        backgroundImageView.addSubviews(explanationLabel, divider, createdAtLabel, metCountLabel)
         addSubviews(backgroundImageView)
     }
     
     override func setupAutoLayout() {
-        divider.snp.makeConstraints {
-            $0.width.equalTo(1)
-        }
-        
-        horizontalStackView.snp.makeConstraints {
+        explanationLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(20)
             $0.leading.equalToSuperview().offset(16)
         }
         
+        divider.snp.makeConstraints {
+            $0.leading.equalTo(explanationLabel.snp.trailing).offset(12)
+            $0.centerY.equalTo(explanationLabel)
+        }
+        
+        createdAtLabel.snp.makeConstraints {
+            $0.leading.equalTo(divider.snp.trailing).offset(12)
+            $0.centerY.equalTo(explanationLabel)
+        }
+        
         metCountLabel.snp.makeConstraints {
-            $0.top.equalTo(horizontalStackView.snp.bottom).offset(2)
-            $0.leading.equalTo(horizontalStackView)
+            $0.top.equalTo(explanationLabel.snp.bottom).offset(2)
+            $0.leading.equalTo(explanationLabel)
             $0.bottom.equalToSuperview().offset(-20)
         }
         

--- a/KkuMulKum/Source/MeetingInfo/View/MeetingInfoView.swift
+++ b/KkuMulKum/Source/MeetingInfo/View/MeetingInfoView.swift
@@ -57,12 +57,6 @@ final class MeetingInfoView: BaseView {
         $0.setText("모임 참여 인원 0명", style: .body01, color: .gray8)
     }
     
-    private let arrowButton = UIButton().then {
-        let image = UIImage(resource: .iconRight).withTintColor(.gray4)
-        $0.setImage(image, for: .normal)
-        $0.contentMode = .scaleAspectFill
-    }
-    
     private let createPromiseButton = UIButton(backgroundColor: .maincolor).then {
         $0.setTitle("+   약속추가", style: .body01, color: .white)
         $0.layer.cornerRadius = Screen.height(52) / 2
@@ -102,7 +96,7 @@ final class MeetingInfoView: BaseView {
         )
         emptyDescriptionView.addSubviews(emptyDescriptionLabel)
         addSubviews(
-            infoBanner, memberCountLabel, arrowButton, memberListView, createPromiseButton,
+            infoBanner, memberCountLabel, memberListView, createPromiseButton,
             grayBackgroundView
         )
         bringSubviewToFront(createPromiseButton)
@@ -119,11 +113,6 @@ final class MeetingInfoView: BaseView {
         memberCountLabel.snp.makeConstraints {
             $0.top.equalTo(infoBanner.snp.bottom).offset(20)
             $0.leading.equalTo(infoBanner)
-        }
-        
-        arrowButton.snp.makeConstraints {
-            $0.trailing.equalToSuperview().offset(-20)
-            $0.centerY.equalTo(memberCountLabel)
         }
         
         memberListView.snp.makeConstraints {

--- a/KkuMulKum/Source/MeetingInfo/ViewModel/MeetingInfoViewModel.swift
+++ b/KkuMulKum/Source/MeetingInfo/ViewModel/MeetingInfoViewModel.swift
@@ -218,7 +218,7 @@ private extension MeetingInfoViewModel {
         if 0 < dDay {
             return ("+\(dDay)", .past)
         } else if 0 == dDay {
-            return ("-Day", .today)
+            return ("-DAY", .today)
         } else {
             return ("\(dDay)", .future)
         }

--- a/KkuMulKum/Source/MeetingInfo/ViewModel/MeetingInfoViewModel.swift
+++ b/KkuMulKum/Source/MeetingInfo/ViewModel/MeetingInfoViewModel.swift
@@ -57,7 +57,33 @@ extension MeetingInfoViewModel: ViewModelType {
             }
             .disposed(by: disposeBag)
         
-        let info = infoRelay.asDriver(onErrorJustReturn: nil)
+        let info = infoRelay
+            .map { info -> MeetingInfoModel? in
+                guard let info else {
+                    print("MeetingInfoModel이 존재하지 않습니다.")
+                    return nil
+                }
+                
+                let dateFormatter = DateFormatter()
+                dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+                
+                guard let date = dateFormatter.date(from: info.createdAt) else {
+                    print("서버의 date가 형식에 맞지 않습니다.")
+                    return nil
+                }
+                
+                dateFormatter.dateFormat = "yyyy.MM.dd"
+                let dateString = dateFormatter.string(from: date)
+                
+                return MeetingInfoModel(
+                    meetingID: info.meetingID,
+                    name: info.name,
+                    createdAt: dateString,
+                    metCount: info.metCount,
+                    invitationCode: info.invitationCode
+                )
+            }
+            .asDriver(onErrorJustReturn: nil)
         
         let memberCount = meetingMemberModelRelay
             .compactMap { $0?.memberCount }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #353

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- Notion '1차 QA 기록' 페이지에 적인 모임 상세 화면 QA 반영

|    구현 내용    |   IPhone 13 mini   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/a2ad416a-5c74-45bc-a3a1-9b62cad554f1" width ="250"> |

- PrivacyInfo.plist의 테스트 토큰에 제 토큰을 넣었음에도 테스트효은으로 로그인이 되더라구요.. 꼬인건지..

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### QA 5가지
- [x] '모임 참여 인원' 우측 화살표 삭제
- [x] 플러스 버튼 '+' 정중앙으로 오도록 수정
- [x] 'D-DAY' 대문자로 표현
- [x] '모임 생성일' 수정된 DateFormat 반영
- [x] '모임 생성일 | 날짜' 간격 수정

<br>

- 5가지에 대해서 각 커밋별로 반영하였습니다.
- 'files changed'로 보시기 보다는 각 커밋별로 보시는 편이 좋을 것 같습니다.

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

### 바텀 시트 애니메이션 관련
<img src="https://github.com/user-attachments/assets/d8764891-cf97-40d6-9a97-4e4cb4bee25d" width=250>

- 애니메이션이 빈 화면(흐린 영역)을 터치할 때와 버튼(취소)를 눌렀을 때 다르게 동작하는데, 이를 개선해야 할 것 같습니다.
- 아무래도 취소 버튼을 터치 시에는 `dismiss`를 호출하다 보니 그렇게 된 것 같은데, 상위 뷰컨트롤러인 BottomSheetController의 메서드를 어떻게 호출해야 할 지에 대한 고민을 해보겠습니다.
- 아니면, 아예 새로 객체를 구현하는 방법도..
